### PR TITLE
Compile and install triton main branch in the docker.

### DIFF
--- a/.ci/tritonbench/install-triton-main.sh
+++ b/.ci/tritonbench/install-triton-main.sh
@@ -23,5 +23,10 @@ conda create --name "${CONDA_ENV}" -y --clone "${BASE_CONDA_ENV}"
 conda activate "${CONDA_ENV}"
 
 . "${SETUP_SCRIPT}"
-# Install the nightly openai/triton
-pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ triton-nightly
+
+# Install and build triton from source code
+cd /workspace
+git clone https://github.com/triton-lang/triton.git
+cd /workspace/triton
+pip install ninja cmake wheel pybind11; # build-time dependencies
+pip install -e python

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -3,7 +3,8 @@ ARG BASE_IMAGE=xzhao9/gcp-a100-runner-dind:latest
 
 FROM ${BASE_IMAGE}
 
-ENV CONDA_ENV=tritonbench
+ENV CONDA_ENV=pytorch
+ENV CONDA_ENV_TRITON_MAIN=triton-main
 ENV SETUP_SCRIPT=/workspace/setup_instance.sh
 ARG TRITONBENCH_BRANCH=${TRITONBENCH_BRANCH:-main}
 ARG FORCE_DATE=${FORCE_DATE}
@@ -41,17 +42,21 @@ RUN cd /workspace/tritonbench && \
         python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"; \
     fi
 
-# Tritonbench library build and test require libcuda.so.1
-# which is from NVIDIA driver
-RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf
+# # Tritonbench library build and test require libcuda.so.1
+# # which is from NVIDIA driver
+# RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf
 
-# Install Tritonbench
+# # Install Tritonbench
+# RUN cd /workspace/tritonbench && \
+#     bash .ci/tritonbench/install.sh
+
+# # Test Tritonbench
+# RUN cd /workspace/tritonbench && \
+#     bash .ci/tritonbench/test-install.sh
+
+# # Remove NVIDIA driver library - they are supposed to be mapped at runtime
+# RUN sudo apt-get purge -y libnvidia-compute-550
+
+# Clone the pytorch env as triton-main env, then compile triton main from source
 RUN cd /workspace/tritonbench && \
-    bash .ci/tritonbench/install.sh
-
-# Test Tritonbench
-RUN cd /workspace/tritonbench && \
-    bash .ci/tritonbench/test-install.sh
-
-# Remove NVIDIA driver library - they are supposed to be mapped at runtime
-RUN sudo apt-get purge -y libnvidia-compute-550
+    BASE_CONDA_ENV=${CONDA_ENV} CONDA_ENV=${CONDA_ENV_TRITON_MAIN} bash .ci/tritonbench/install-triton-main.sh

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -42,20 +42,21 @@ RUN cd /workspace/tritonbench && \
         python utils/cuda_utils.py --check-torch-nightly-version --force-date "${FORCE_DATE}"; \
     fi
 
-# # Tritonbench library build and test require libcuda.so.1
-# # which is from NVIDIA driver
-# RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf
+# Tritonbench library build and test require libcuda.so.1
+# which is from NVIDIA driver
+RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf
 
-# # Install Tritonbench
-# RUN cd /workspace/tritonbench && \
-#     bash .ci/tritonbench/install.sh
+# Install Tritonbench
+RUN cd /workspace/tritonbench && \
+    bash .ci/tritonbench/install.sh
 
-# # Test Tritonbench
-# RUN cd /workspace/tritonbench && \
-#     bash .ci/tritonbench/test-install.sh
 
-# # Remove NVIDIA driver library - they are supposed to be mapped at runtime
-# RUN sudo apt-get purge -y libnvidia-compute-550
+# Test Tritonbench
+RUN cd /workspace/tritonbench && \
+    bash .ci/tritonbench/test-install.sh
+
+# Remove NVIDIA driver library - they are supposed to be mapped at runtime
+RUN sudo apt-get purge -y libnvidia-compute-550
 
 # Clone the pytorch env as triton-main env, then compile triton main from source
 RUN cd /workspace/tritonbench && \


### PR DESCRIPTION
We want to support two triton versions in our docker: the version bundled with pytorch, and the main branch.

This PR uses the `pytorch` conda env as the default, and also installs `triton-main` conda env which uses the main branch Triton.