### PR TITLE
Fix loading ThunderKitten libraries

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -99,7 +99,7 @@ try:
         # colfax Flash Attention V2 for Hopper
         torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
     else:
-        from userbenchmark.triton.loader import load_library
+        from tritonbench.utils.loader import load_library
 
         load_library("cutlass_kernels/fmha_forward_lib.so")
     colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward

--- a/tritonbench/utils/loader.py
+++ b/tritonbench/utils/loader.py
@@ -5,5 +5,5 @@ def load_library(library_path: str):
     import torch
 
     prefix, _delimiter, so_file = library_path.partition("/")
-    so_full_path = REPO_PATH.joinpath(prefix, ".data", so_file).resolve()
+    so_full_path = REPO_PATH.joinpath("utils", prefix, ".data", so_file).resolve()
     torch.ops.load_library(str(so_full_path))

--- a/tritonbench/utils/path_utils.py
+++ b/tritonbench/utils/path_utils.py
@@ -3,7 +3,7 @@ import sys
 
 from pathlib import Path
 
-REPO_PATH = Path(os.path.abspath(__file__)).parent.parent
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
 SUBMODULE_PATH = REPO_PATH.joinpath("submodules")
 
 


### PR DESCRIPTION
As mentioned in https://github.com/pytorch-labs/tritonbench/issues/17

Test plan:

```
(base) ➜  tritonbench git:(xz9/fix-tk-load) python -c "from tritonbench.utils.loader import load_library; load_library('tk/tk_attn_h100_fwd.so')"
(base) ➜  tritonbench git:(xz9/fix-tk-load) echo $?
0
```