### PR TITLE
Add layernorm and fix bug for embedding bwd

### DIFF
--- a/tritonbench/operators/embedding/operator.py
+++ b/tritonbench/operators/embedding/operator.py
@@ -50,4 +50,4 @@ class Operator(BenchmarkOperator):
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()
         do = torch.randn_like(y)
-        return lambda: y.backward(do)
+        return lambda: y.backward(do, retain_graph=True)

--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -13,6 +13,10 @@ from tritonbench.utils.triton_op import (
 
 from . import tutorial
 
+try:
+    from liger_kernel.ops.layer_norm import LigerLayerNormFunction
+except ModuleNotFoundError:
+    LigerLayerNormFunction = None
 
 class Operator(BenchmarkOperator):
     @register_benchmark()
@@ -30,6 +34,11 @@ class Operator(BenchmarkOperator):
             return F.layer_norm(*args)
 
         return lambda: inner(*args)
+
+    @register_benchmark(enabled=True, ci=False)
+    def liger_layer_norm(self, *args):
+        (x, w_shape, weight, bias, eps) = args
+        return lambda: LigerLayerNormFunction.apply(x, weight, bias, eps)
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -15,8 +15,10 @@ from . import tutorial
 
 try:
     from liger_kernel.ops.layer_norm import LigerLayerNormFunction
+    HAS_LIGER_KERNEL = True
 except ModuleNotFoundError:
     LigerLayerNormFunction = None
+    HAS_LIGER_KERNEL = False
 
 class Operator(BenchmarkOperator):
     @register_benchmark()
@@ -35,7 +37,7 @@ class Operator(BenchmarkOperator):
 
         return lambda: inner(*args)
 
-    @register_benchmark(enabled=True, ci=False)
+    @register_benchmark(ci=HAS_LIGER_KERNEL)
     def liger_layer_norm(self, *args):
         (x, w_shape, weight, bias, eps) = args
         return lambda: LigerLayerNormFunction.apply(x, weight, bias, eps)


### PR DESCRIPTION
Add layernorm from liger kernel and fix bug for embedding bwd. Disable liger kernels in internal ci.

Test Plan:

```
python run.py --op layer_norm --num-inputs 4 --metrics latency  
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:15<00:00,  3.81s/it]
  x_val    torch_layer_norm-latency    triton_layer_norm-latency    torch_compile_layer_norm-latency    liger_layer_norm-latency
-------  --------------------------  ---------------------------  ----------------------------------  --------------------------
   1024                    0.028896                     0.024512                            0.02448                     0.023808
   1536                    0.038688                     0.034144                            0.05584                     0.033536
   2048                    0.048704                     0.043424                            0.059424                    0.043104
   2560                    0.058112                     0.05472                             0.083712                    0.054176
```