### PR TITLE
Format benchmark function names and change x_val to corresponding input shapes

### DIFF
--- a/tritonbench/operators/embedding/operator.py
+++ b/tritonbench/operators/embedding/operator.py
@@ -1,10 +1,14 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 from torch.nn import Embedding
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.experimental.embedding import LigerEmbedding
@@ -46,6 +50,11 @@ class Operator(BenchmarkOperator):
         self.baseline_op = Embedding(V, D).to(self.device).to(self.dtype)
         compiled = torch.compile(self.baseline_op, dynamic=False)
         return lambda: compiled(input)
+
+    @register_x_val(label="(B, T, D, V)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
+        V, D, input_tensor = example_inputs
+        return (input_tensor.size(0), input_tensor.size(1), D, V)
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/fused_linear_jsd/operator.py
+++ b/tritonbench/operators/fused_linear_jsd/operator.py
@@ -1,9 +1,13 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.fused_linear_jsd import LigerFusedLinearJSD
@@ -164,6 +168,10 @@ class Operator(BenchmarkOperator):
     def inductor_lm_head_jsd(self, student_input, teacher_input) -> Callable:
         compiled = torch.compile(self.baseline_op, dynamic=False)
         return lambda: compiled(student_input, teacher_input)
+
+    @register_x_val(label="(B*T, H)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int]:
+        return (example_inputs[0].size(0), example_inputs[0].size(1))
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/jsd/operator.py
+++ b/tritonbench/operators/jsd/operator.py
@@ -1,9 +1,13 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.jsd import LigerJSD
@@ -85,6 +89,11 @@ class Operator(BenchmarkOperator):
     def inductor_jsd(self, _input, target) -> Callable:
         compiled = torch.compile(self.baseline_op, dynamic=False)
         return lambda: compiled(_input, target)
+
+    @register_x_val(label="(B, T, V)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
+        input_tensor = example_inputs[0]
+        return (self.B, self.T, input_tensor.size(1))
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/kl_div/operator.py
+++ b/tritonbench/operators/kl_div/operator.py
@@ -1,9 +1,13 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.kl_div import LigerKLDIVLoss
@@ -45,6 +49,11 @@ class Operator(BenchmarkOperator):
     def inductor_kl_div(self, input, target) -> Callable:
         compiled = torch.compile(self.baseline_op, dynamic=False)
         return lambda: compiled(input, target)
+
+    @register_x_val(label="(B, T, V)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
+        input_tensor = example_inputs[0]
+        return (self.B, self.T, input_tensor.size(1))
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -1,9 +1,13 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.rms_norm import LigerRMSNorm
@@ -63,6 +67,10 @@ class Operator(BenchmarkOperator):
     def inductor_rms(self, H, input) -> Callable:
         compiled = torch.compile(self.llama_rms_op, dynamic=False)
         return lambda: compiled(input)
+
+    @register_x_val(label="(M, H)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int]:
+        return (self.M, example_inputs[0])
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()

--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -1,11 +1,15 @@
 import argparse
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Generator, List, Optional, Tuple
 
 import torch
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaMLP
 
-from tritonbench.utils.triton_op import BenchmarkOperator, register_benchmark
+from tritonbench.utils.triton_op import (
+    BenchmarkOperator,
+    register_benchmark,
+    register_x_val,
+)
 
 try:
     from liger_kernel.transformers.swiglu import LigerSwiGLUMLP
@@ -58,6 +62,10 @@ class Operator(BenchmarkOperator):
     def inductor_swiglu(self, input) -> Callable:
         compiled = torch.compile(self.baseline_op, dynamic=False)
         return lambda: compiled(input)
+
+    @register_x_val(label="(B, T, H)")
+    def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
+        return (self.B, example_inputs[0].size(1), example_inputs[0].size(2))
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         y = fwd_fn()


### PR DESCRIPTION
Fix https://github.com/pytorch-labs/tritonbench/issues/31 
Test Plan:

```
% python run.py --op fused_linear_cross_entropy --num-inputs 1 --metrics latency
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:13<00:00, 13.02s/it]
    (B*T, H)    torch_lm_head_ce-latency    liger_lm_head_ce-latency    inductor_fused_linear_cross_entropy-latency
------------  --------------------------  --------------------------  ---------------------------------------------
(4096, 4096)                     145.728                     526.446                                        144.567
```