### PR TITLE
Add transformers to dependency and pin its version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 packaging
 pynvml
+transformers==4.46.1


### PR DESCRIPTION
Since liger kernels depend on transformers, we need to add transformers to tritonbench's requirements.txt 