### PR TITLE
Fix hstu on OSS

### DIFF
--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -147,7 +147,6 @@ class RaggedHSTUAttn(torch.nn.Module):
             del kwargs["contextual_seq_len"]
             del kwargs["HAS_SORT_BY_LENGTH_INDICES"]
             del kwargs["sort_by_length_indices"]
-            del kwargs["AUTOTUNE_MAX_SEQ_LEN"]
             kwargs["HAS_MAX_ATTN_LEN"] = False
             kwargs["max_attn_len"] = 0
 

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -144,8 +144,14 @@ class RaggedHSTUAttn(torch.nn.Module):
         if not IS_FBCODE:
             del kwargs["MAX_ATTN_LEN"]
             del kwargs["HAS_CONTEXTUAL_SEQ_LEN"]
+            del kwargs["contextual_seq_len"]
+            del kwargs["AUTOTUNE_MAX_SEQ_LEN"]
+            del kwargs["HAS_SORT_BY_LENGTH_INDICES"]
+            del kwargs["sort_by_length_indices"]
+            del kwargs["AUTOTUNE_MAX_SEQ_LEN"]
             kwargs["HAS_MAX_ATTN_LEN"] = False
             kwargs["max_attn_len"] = 0
+
         if self.persistent_kernel:
             grid = (1216,)
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -143,6 +143,7 @@ class RaggedHSTUAttn(torch.nn.Module):
         }
         if not IS_FBCODE:
             del kwargs["MAX_ATTN_LEN"]
+            del kwargs["HAS_CONTEXTUAL_SEQ_LEN"]
             kwargs["HAS_MAX_ATTN_LEN"] = False
             kwargs["max_attn_len"] = 0
         if self.persistent_kernel:

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -145,7 +145,6 @@ class RaggedHSTUAttn(torch.nn.Module):
             del kwargs["MAX_ATTN_LEN"]
             del kwargs["HAS_CONTEXTUAL_SEQ_LEN"]
             del kwargs["contextual_seq_len"]
-            del kwargs["AUTOTUNE_MAX_SEQ_LEN"]
             del kwargs["HAS_SORT_BY_LENGTH_INDICES"]
             del kwargs["sort_by_length_indices"]
             del kwargs["AUTOTUNE_MAX_SEQ_LEN"]

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -1,5 +1,6 @@
 import torch
 import triton
+from tritonbench.utils.triton_op import IS_FBCODE
 from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 try:
@@ -140,6 +141,10 @@ class RaggedHSTUAttn(torch.nn.Module):
             "HAS_SORT_BY_LENGTH_INDICES": False,
             "sort_by_length_indices": None,
         }
+        if not IS_FBCODE:
+            del kwargs["MAX_ATTN_LEN"]
+            kwargs["HAS_MAX_ATTN_LEN"] = False
+            kwargs["max_attn_len"] = 0
         if self.persistent_kernel:
             grid = (1216,)
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -161,9 +161,9 @@ def get_parser(args=None):
         help="Run each operator in a separate child process. By default, it will always continue on failure.",
     )
     parser.add_argument(
-        "--fail-fast",
+        "--bypass-fail",
         action="store_true",
-        help="stops run on operator failure. Helpful for local development",
+        help="bypass and continue on operator failure.",
     )
 
     if IS_FBCODE:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -932,7 +932,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                             grad_to_none=self.get_grad_to_none(self.example_inputs),
                         )
                     except Exception as e:
-                        if self.tb_args.fail_fast:
+                        if not self.tb_args.bypass_fail:
                             raise e
                         metrics.latency = None
             if {"gpu_peak_mem", "gpu_mem_footprint", "cpu_peak_mem"} & set(


### PR DESCRIPTION
HSTU OSS HEAD is broken right now so we can't do the upgrade: https://github.com/facebookresearch/generative-recommenders/issues/115

We will use the old commit for HSTU OSS, and handle it separately in fbcode.

Test case:

```
$ python run.py --op ragged_attention --only hstu_triton_ragged_attention --max-seq-len-log2 13 --batch-size 128 --num-inputs 1
```