### PR TITLE
Update HSTU and use the OSS wrapper for non-persisent kernels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Dao-AILab/flash-attention.git
 [submodule "submodules/generative-recommenders"]
 	path = submodules/generative-recommenders
-	url = https://github.com/facebookresearch/generative-recommenders.git
+	url = https://github.com/xuzhao9/generative-recommenders.git
 [submodule "submodules/kernels"]
 	path = submodules/kernels
 	url = https://github.com/triton-lang/kernels.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Dao-AILab/flash-attention.git
 [submodule "submodules/generative-recommenders"]
 	path = submodules/generative-recommenders
-	url = https://github.com/xuzhao9/generative-recommenders.git
+	url = https://github.com/facebookresearch/generative-recommenders.git
 [submodule "submodules/kernels"]
 	path = submodules/kernels
 	url = https://github.com/triton-lang/kernels.git

--- a/install.py
+++ b/install.py
@@ -114,6 +114,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--fa3", action="store_true", help="Install optional flash_attention 3 kernels"
     )
+    parser.add_argument("--hstu", action="store_true", help="Install HSTU.")
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
     parser.add_argument("--tk", action="store_true", help="Install ThunderKittens")
     parser.add_argument("--liger", action="store_true", help="Install Liger-kernel")
@@ -153,6 +154,10 @@ if __name__ == "__main__":
     if args.xformers or args.all:
         logger.info("[tritonbench] installing xformers...")
         install_xformers()
+    if args.hstu or args.all:
+        logger.info("[tritonbench] installing hstu...")
+        from tools.hstu.install import install_hstu
+        install_hstu()
     logger.info("[tritonbench] installation complete!")
     # run tests to check installation
     if args.test:

--- a/tools/hstu/hstu.patch
+++ b/tools/hstu/hstu.patch
@@ -1,0 +1,13 @@
+diff --git a/generative_recommenders/ops/triton/triton_ragged_hstu_attention.py b/generative_recommenders/ops/triton/triton_ragged_hstu_attention.py
+index b4e318b..d6bc894 100644
+--- a/generative_recommenders/ops/triton/triton_ragged_hstu_attention.py
++++ b/generative_recommenders/ops/triton/triton_ragged_hstu_attention.py
+@@ -36,7 +36,7 @@ try:
+         VersionedSpec,
+     )
+ except ImportError:
+-    from hammer.oss.generative_recommenders.ops.triton.utils import (
++    from generative_recommenders.ops.triton.utils import (
+         _switch_to_contiguous_if_needed,
+         autotune_max_seq_len,
+         NamedSpecType,

--- a/tools/hstu/install.py
+++ b/tools/hstu/install.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+PATCH_DIR = str(Path(__file__).parent.parent.parent.joinpath("submodules", "generative-recommenders").absolute())
+PATCH_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hstu.patch")
+
+
+def install_hstu():
+    try:
+        subprocess.check_output(
+            [
+                "patch",
+                "-p1",
+                "--forward",
+                "-i",
+                PATCH_FILE,
+                "-r",
+                "/tmp/rej",
+            ],
+            cwd=PATCH_DIR,
+        )
+    except subprocess.SubprocessError as e:
+        output_str = str(e.output)
+        if "previously applied" in output_str:
+            return
+        else:
+            print(str(output_str))
+            sys.exit(1)

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -15,10 +15,13 @@ except ModuleNotFoundError:
     # OSS Import
     with add_path(str(SUBMODULE_PATH.joinpath("generative-recommenders"))):
         from generative_recommenders.ops.triton import triton_ragged_hstu_attention
+
         _ragged_hstu_attn_fwd_persistent = (
             triton_ragged_hstu_attention._ragged_hstu_attn_fwd_persistent
         )
-        _RaggedAttentionRelativeBiasFunction = triton_ragged_hstu_attention._RaggedAttentionRelativeBiasFunction
+        _RaggedAttentionRelativeBiasFunction = (
+            triton_ragged_hstu_attention._RaggedAttentionRelativeBiasFunction
+        )
 
     @torch.fx.wrap
     def prev_power_of_2(x: int) -> int:
@@ -55,13 +58,17 @@ class RaggedHSTUAttn(torch.nn.Module):
             torch.randn(
                 (self.num_buckets + 1,),
                 dtype=torch.bfloat16,
-            ).requires_grad_(requires_grad).cuda()
+            )
+            .requires_grad_(True)
+            .cuda()
         )
         self.all_pos_weights = torch.nn.Parameter(
             torch.randn(
                 (2 * self.max_seq_len - 1,),
                 dtype=torch.bfloat16,
-            ).requires_grad_(requires_grad).cuda()
+            )
+            .requires_grad_(True)
+            .cuda()
         )
         self.persistent_kernel = persistent_kernel
 
@@ -144,7 +151,7 @@ class RaggedHSTUAttn(torch.nn.Module):
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)
         else:
             _RaggedAttentionRelativeBiasFunction.apply(
-                self.max_seq_len, # N
+                self.max_seq_len,  # N
                 kwargs["alpha"],
                 q,
                 k,
@@ -152,21 +159,21 @@ class RaggedHSTUAttn(torch.nn.Module):
                 kwargs["seq_offsets"],
                 kwargs["INVALID_MASK_TYPE"],
                 timestamps,
-                self.all_ts_weights, # ts_weights
-                self.all_pos_weights, # pos_weights
-                kwargs["CAUSAL"], # causal,
-                kwargs["num_buckets"], # num_buckets
-                "sqrt", # time_bucket_fn
-                kwargs["time_bucket_incr"], # time_bucket_incr
-                kwargs["time_bucket_div"], # time_bucket_div
-                kwargs["time_delta"], # time_delta
-                kwargs["max_pos_ind"], # max_pos_ind
+                self.all_ts_weights,  # ts_weights
+                self.all_pos_weights,  # pos_weights
+                kwargs["CAUSAL"],  # causal,
+                kwargs["num_buckets"],  # num_buckets
+                "sqrt",  # time_bucket_fn
+                kwargs["time_bucket_incr"],  # time_bucket_incr
+                kwargs["time_bucket_div"],  # time_bucket_div
+                kwargs["time_delta"],  # time_delta
+                kwargs["max_pos_ind"],  # max_pos_ind
                 kwargs["num_targets"],
-                None, # attn_scale
-                kwargs["ATTN_BIAS_TYPE"], # relative_bias_type
-                kwargs["MAX_ATTN_LEN"], # max_attn_len
-                kwargs["contextual_seq_len"], # contextual_seq_len
-                kwargs["sort_by_length_indices"] # sort_by_length
+                None,  # attn_scale
+                kwargs["ATTN_BIAS_TYPE"],  # relative_bias_type
+                kwargs["MAX_ATTN_LEN"],  # max_attn_len
+                kwargs["contextual_seq_len"],  # contextual_seq_len
+                kwargs["sort_by_length_indices"],  # sort_by_length
             )
 
         return out
@@ -175,29 +182,20 @@ class RaggedHSTUAttn(torch.nn.Module):
 def get_test_inputs(
     batch_size, num_heads, max_seq_len, requires_grad
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    timestamp_deltas: torch.Tensor = (
-        torch.randint(
-            86400,
-            size=(batch_size, max_seq_len + 1),
-        )
-        .cuda()
-    )
+    timestamp_deltas: torch.Tensor = torch.randint(
+        86400,
+        size=(batch_size, max_seq_len + 1),
+    ).cuda()
     timestamps = timestamp_deltas.cumsum(dim=1)
 
-    lengths = (
-        torch.randint(
-            max_seq_len + 1,
-            size=(batch_size,),
-        )
-        .cuda()
-    )
-    seq_offsets = (
-        torch.zeros(
-            (batch_size + 1,),
-            dtype=torch.int64,
-        )
-        .cuda()
-    )
+    lengths = torch.randint(
+        max_seq_len + 1,
+        size=(batch_size,),
+    ).cuda()
+    seq_offsets = torch.zeros(
+        (batch_size + 1,),
+        dtype=torch.int64,
+    ).cuda()
     seq_offsets[1:] = torch.cumsum(
         lengths,
         dim=0,
@@ -209,7 +207,7 @@ def get_test_inputs(
             (L, num_heads, 512),
             dtype=torch.bfloat16,
         )
-        .requires_grad_(requires_grad)
+        .requires_grad_(True)
         .cuda()
     )
     return qkv, seq_offsets, timestamps

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -43,6 +43,7 @@ class RaggedHSTUAttn(torch.nn.Module):
         num_heads,
         max_seq_len,
         num_buckets,
+        requires_grad,
         persistent_kernel: bool = False,
     ) -> None:
         super().__init__()
@@ -54,13 +55,13 @@ class RaggedHSTUAttn(torch.nn.Module):
             torch.randn(
                 (self.num_buckets + 1,),
                 dtype=torch.bfloat16,
-            ).cuda()
+            ).requires_grad_(requires_grad).cuda()
         )
         self.all_pos_weights = torch.nn.Parameter(
             torch.randn(
                 (2 * self.max_seq_len - 1,),
                 dtype=torch.bfloat16,
-            ).cuda()
+            ).requires_grad_(requires_grad).cuda()
         )
         self.persistent_kernel = persistent_kernel
 
@@ -179,7 +180,6 @@ def get_test_inputs(
             86400,
             size=(batch_size, max_seq_len + 1),
         )
-        .requires_grad_(requires_grad)
         .cuda()
     )
     timestamps = timestamp_deltas.cumsum(dim=1)
@@ -189,7 +189,6 @@ def get_test_inputs(
             max_seq_len + 1,
             size=(batch_size,),
         )
-        .requires_grad_(requires_grad)
         .cuda()
     )
     seq_offsets = (
@@ -197,7 +196,6 @@ def get_test_inputs(
             (batch_size + 1,),
             dtype=torch.int64,
         )
-        .requires_grad_(requires_grad)
         .cuda()
     )
     seq_offsets[1:] = torch.cumsum(

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -150,7 +150,7 @@ class RaggedHSTUAttn(torch.nn.Module):
             grid = (1216,)
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)
         else:
-            _RaggedAttentionRelativeBiasFunction.apply(
+            out = _RaggedAttentionRelativeBiasFunction.apply(
                 self.max_seq_len,  # N
                 kwargs["alpha"],
                 q,

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -15,10 +15,8 @@ except ModuleNotFoundError:
     # OSS Import
     import importlib
 
-    with add_path(str(SUBMODULE_PATH)):
-        triton_ragged_hstu_attention = importlib.import_module(
-            "generative-recommenders.ops.triton.triton_ragged_hstu_attention"
-        )
+    with add_path(str(SUBMODULE_PATH.joinpath("generative-recommenders"))):
+        from generative_recommenders.ops.triton import triton_ragged_hstu_attention
         _ragged_hstu_attn_fwd_persistent = (
             triton_ragged_hstu_attention._ragged_hstu_attn_fwd_persistent
         )
@@ -147,7 +145,7 @@ class RaggedHSTUAttn(torch.nn.Module):
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)
         else:
             kwargs = {
-                "max_seq_len": kwargs["max_seq_len"],
+                "max_seq_len": self.max_seq_len,
                 "alpha": kwargs["alpha"],
                 "q": kwargs["q"],
                 "k": kwargs["k"],

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -142,17 +142,16 @@ class RaggedHSTUAttn(torch.nn.Module):
             grid = (1216,)
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)
         else:
-            kwargs = {
-                "max_seq_len": self.max_seq_len,
-                "alpha": kwargs["alpha"],
-                "q": kwargs["Q"],
-                "k": kwargs["K"],
-                "v":kwargs["V"],
-                "seq_offsets": kwargs["seq_offsets"],
-                "invalid_attn_mask_type": kwargs["INVALID_MASK_TYPE"],
-                "num_targets": kwargs["num_targets"],
-            }
-            _RaggedAttentionRelativeBiasFunction.apply(**kwargs)
+            _RaggedAttentionRelativeBiasFunction.apply(
+                self.max_seq_len,
+                kwargs["alpha"],
+                q,
+                k,
+                v,
+                kwargs["seq_offsets"],
+                kwargs["INVALID_MASK_TYPE"],
+                kwargs["num_targets"]
+            )
 
         return out
 

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -143,14 +143,29 @@ class RaggedHSTUAttn(torch.nn.Module):
             _ragged_hstu_attn_fwd_persistent[grid](**kwargs)
         else:
             _RaggedAttentionRelativeBiasFunction.apply(
-                self.max_seq_len,
+                self.max_seq_len, # N
                 kwargs["alpha"],
                 q,
                 k,
                 v,
                 kwargs["seq_offsets"],
                 kwargs["INVALID_MASK_TYPE"],
-                kwargs["num_targets"]
+                timestamps,
+                self.all_ts_weights, # ts_weights
+                self.all_pos_weights, # pos_weights
+                kwargs["CAUSAL"], # causal,
+                kwargs["num_buckets"], # num_buckets
+                "sqrt", # time_bucket_fn
+                kwargs["time_bucket_incr"], # time_bucket_incr
+                kwargs["time_bucket_div"], # time_bucket_div
+                kwargs["time_delta"], # time_delta
+                kwargs["max_pos_ind"], # max_pos_ind
+                kwargs["num_targets"],
+                None, # attn_scale
+                kwargs["ATTN_BIAS_TYPE"], # relative_bias_type
+                kwargs["MAX_ATTN_LEN"], # max_attn_len
+                kwargs["contextual_seq_len"], # contextual_seq_len
+                kwargs["sort_by_length_indices"] # sort_by_length
             )
 
         return out

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -59,7 +59,7 @@ class RaggedHSTUAttn(torch.nn.Module):
                 (self.num_buckets + 1,),
                 dtype=torch.bfloat16,
             )
-            .requires_grad_(True)
+            .requires_grad_(requires_grad)
             .cuda()
         )
         self.all_pos_weights = torch.nn.Parameter(
@@ -67,7 +67,7 @@ class RaggedHSTUAttn(torch.nn.Module):
                 (2 * self.max_seq_len - 1,),
                 dtype=torch.bfloat16,
             )
-            .requires_grad_(True)
+            .requires_grad_(requires_grad)
             .cuda()
         )
         self.persistent_kernel = persistent_kernel
@@ -207,7 +207,7 @@ def get_test_inputs(
             (L, num_heads, 512),
             dtype=torch.bfloat16,
         )
-        .requires_grad_(True)
+        .requires_grad_(requires_grad)
         .cuda()
     )
     return qkv, seq_offsets, timestamps

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -13,8 +13,6 @@ try:
     )
 except ModuleNotFoundError:
     # OSS Import
-    import importlib
-
     with add_path(str(SUBMODULE_PATH.joinpath("generative-recommenders"))):
         from generative_recommenders.ops.triton import triton_ragged_hstu_attention
         _ragged_hstu_attn_fwd_persistent = (
@@ -147,11 +145,11 @@ class RaggedHSTUAttn(torch.nn.Module):
             kwargs = {
                 "max_seq_len": self.max_seq_len,
                 "alpha": kwargs["alpha"],
-                "q": kwargs["q"],
-                "k": kwargs["k"],
-                "v":kwargs["v"],
+                "q": kwargs["Q"],
+                "k": kwargs["K"],
+                "v":kwargs["V"],
                 "seq_offsets": kwargs["seq_offsets"],
-                "invalid_attn_mask_type": kwargs["invalid_attn_mask_type"],
+                "invalid_attn_mask_type": kwargs["INVALID_MASK_TYPE"],
                 "num_targets": kwargs["num_targets"],
             }
             _RaggedAttentionRelativeBiasFunction.apply(**kwargs)

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -172,14 +172,14 @@ class RaggedHSTUAttn(torch.nn.Module):
 
 
 def get_test_inputs(
-    batch_size, num_heads, max_seq_len
+    batch_size, num_heads, max_seq_len, requires_grad
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     timestamp_deltas: torch.Tensor = (
         torch.randint(
             86400,
             size=(batch_size, max_seq_len + 1),
         )
-        .requires_grad_(False)
+        .requires_grad_(requires_grad)
         .cuda()
     )
     timestamps = timestamp_deltas.cumsum(dim=1)
@@ -189,7 +189,7 @@ def get_test_inputs(
             max_seq_len + 1,
             size=(batch_size,),
         )
-        .requires_grad_(False)
+        .requires_grad_(requires_grad)
         .cuda()
     )
     seq_offsets = (
@@ -197,7 +197,7 @@ def get_test_inputs(
             (batch_size + 1,),
             dtype=torch.int64,
         )
-        .requires_grad_(False)
+        .requires_grad_(requires_grad)
         .cuda()
     )
     seq_offsets[1:] = torch.cumsum(
@@ -211,7 +211,7 @@ def get_test_inputs(
             (L, num_heads, 512),
             dtype=torch.bfloat16,
         )
-        .requires_grad_(False)
+        .requires_grad_(requires_grad)
         .cuda()
     )
     return qkv, seq_offsets, timestamps

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -60,8 +60,9 @@ class Operator(BenchmarkOperator):
         return (self.batch_size, self.num_heads, self.max_seq_len, self.num_buckets)
 
     def get_input_iter(self):
+        requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
         for _input_id in range(self._num_inputs):
-            inputs = get_test_inputs(self.batch_size, self.num_heads, self.max_seq_len)
+            inputs = get_test_inputs(self.batch_size, self.num_heads, self.max_seq_len, requires_grad)
             yield inputs
 
     def get_bwd_fn(self, fwd_fn: Callable[..., Any]) -> Callable[..., Any]:

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -85,12 +85,12 @@ class Operator(BenchmarkOperator):
         f1 = 0.0
         f2 = 0.0
         jagged = True
-        seq_offsets = example_inputs["seq_offsets"]
-        q = example_inputs["qkv"][:, :, :128]
-        v = example_inputs["qkv"][:, :, 256:384]
+        qkv, seq_offsets, timestamps = example_inputs
+        q = qkv[:, :, :128]
+        v = qkv[:, :, 256:384]
         _, nheads, attn_dim = q.shape
         _, _, hidden_dim = v.shape
-        max_seqlen = example_inputs["timestamps"].size(1) - 1
+        max_seqlen = timestamps.size(1) - 1
 
         for i in range(self.batch_size):
             seq_len = (

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -82,7 +82,6 @@ class Operator(BenchmarkOperator):
             lambda x: isinstance(x, torch.Tensor),
             o,
         )
-        print(o)
         do = torch.rand_like(o_tensor)
         fn = lambda: o_tensor.backward(do, retain_graph=True)
         return fn


### PR DESCRIPTION
Add the following features to ragged_hstu:

1. Add tflops metric
2. Use _RaggedAttentionRelativeBiasFunction to wrap the Triton kernel
3. Add backward


Test plan:

```
$ python run.py --op ragged_attention --metrics latency,tflops --mode bwd

            x_val    hstu_triton_ragged_attention-tflops    hstu_triton_ragged_attention-latency
-----------------  -------------------------------------  --------------------------------------
(8, 4, 512, 2048)                               0.306747                                2.81939
(8, 4, 512, 2048)                               1.65614                                 0.867936
(8, 4, 512, 2048)                               2.00125                                 0.84768
(8, 4, 512, 2048)                               2.13756                                 0.991968
(8, 4, 512, 2048)                               1.96315                                 0.902976
(8, 4, 512, 2048)                               1.50214                                 0.836192
(8, 4, 512, 2048)                               1.34825                                 0.859936
(8, 4, 512, 2048)                               1.90546                                 0.97408
(8, 4, 512, 2048)                               1.72114                                 0.902368
(8, 4, 512, 2048)                               2.30999                                 1.01107
```