### PR TITLE
[FA] clean up and make TMA, scheduling autotunable

### DIFF
--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -155,7 +155,7 @@ def _attn_fwd_inner(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
+    for start_n in tl.range(lo, hi, BLOCK_N): #, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         if ENABLE_TMA:
@@ -259,7 +259,7 @@ def _attn_fwd_inner_ws(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
+    for start_n in tl.range(lo, hi, BLOCK_N): #, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         with tl.async_task([0]):

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -38,7 +38,6 @@ else:
 
 
 class TmaAutoTuneHelper:
-
     # duck typing wrapper to implement the same interface as TmaDescKernelParam in Triton PR #4498
     class KernelParamWrapper:
         def __init__(self, desc):
@@ -156,9 +155,7 @@ def _attn_fwd_inner(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(
-        lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE
-    ):
+    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         if ENABLE_TMA:
@@ -262,9 +259,7 @@ def _attn_fwd_inner_ws(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(
-        lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE
-    ):
+    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         with tl.async_task([0]):
@@ -342,7 +337,12 @@ schedList = ["FA_secondDot"] if PEEL_LAST else schedList
 configsOpt = [
     (
         triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=4 if sched == "FA_firstDot" or sched == "FA_secondDot" else 3,
             num_warps=w,
             num_buffers_warp_spec=0,
@@ -350,9 +350,14 @@ configsOpt = [
         )
         if has_warp_spec
         else triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=4 if sched == "FA_firstDot" or sched == "FA_secondDot" else 3,
-            num_warps=w
+            num_warps=w,
         )
     )
     for BM in [128]
@@ -365,7 +370,12 @@ configsOpt = [
 configsTma = [
     (
         triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=4 if sched == "FA_firstDot" or sched == "FA_secondDot" else 3,
             num_warps=w,
             num_buffers_warp_spec=0,
@@ -373,9 +383,14 @@ configsTma = [
         )
         if has_warp_spec
         else triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=4 if sched == "FA_firstDot" or sched == "FA_secondDot" else 3,
-            num_warps=w
+            num_warps=w,
         )
     )
     for BM in [128]
@@ -400,7 +415,7 @@ configsWS = [
         else triton.Config(
             {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": False, "LOOP_SCHEDULE": sched},
             num_stages=2 if sched == "FA_firstDot" or sched == "FA_secondDot" else 0,
-            num_warps=w
+            num_warps=w,
         )
     )
     for BM in [128]
@@ -416,25 +431,44 @@ configsWS = [
 configsOrig = [
     (
         triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": False, "LOOP_SCHEDULE": "default"},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": False,
+                "LOOP_SCHEDULE": "default",
+            },
             num_stages=s,
             num_warps=w,
             num_buffers_warp_spec=0,
             num_consumer_groups=0,
         )
         if has_warp_spec
-        else triton.Config({"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": False, "LOOP_SCHEDULE": "default"}, num_stages=s, num_warps=w)
+        else triton.Config(
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": False,
+                "LOOP_SCHEDULE": "default",
+            },
+            num_stages=s,
+            num_warps=w,
+        )
     )
-    for BM in [128] #64, 128]
-    for BN in [128] #64, 128]
-    for s in [3] #, 4, 7]
-    for w in [8] #4, 8]
+    for BM in [128]  # 64, 128]
+    for BN in [128]  # 64, 128]
+    for s in [3]  # , 4, 7]
+    for w in [8]  # 4, 8]
 ]
 # TMA, WS, and CompPipe
 configsTmaWS = [
     (
         triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=2 if sched == "FA_firstDot" or sched == "FA_secondDot" else 0,
             num_warps=w,
             num_buffers_warp_spec=buf,
@@ -444,9 +478,14 @@ configsTmaWS = [
         )
         if has_warp_spec
         else triton.Config(
-            {"BLOCK_M": BM, "BLOCK_N": BN, "ENABLE_TMA": enable_tma, "LOOP_SCHEDULE": sched},
+            {
+                "BLOCK_M": BM,
+                "BLOCK_N": BN,
+                "ENABLE_TMA": enable_tma,
+                "LOOP_SCHEDULE": sched,
+            },
             num_stages=2 if sched == "FA_firstDot" or sched == "FA_secondDot" else 0,
-            num_warps=w
+            num_warps=w,
         )
     )
     for BM in [128]
@@ -1570,7 +1609,6 @@ def _attn_bwd(
 
 
 class _attention_opt(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, q, k, v, causal, sm_scale, baseVariant):
         # shape constraints
@@ -1593,13 +1631,11 @@ class _attention_opt(torch.autograd.Function):
         desc_helper.init_tma_descriptor("o")
 
         def grid_tma(META):
-            if META['ENABLE_TMA'] == False:
+            if META["ENABLE_TMA"] == False:
                 return (
                     # grid partitioning: num_consumer_groups * BLOCK_M
                     # data partitioning: BLOCK_M
-                    triton.cdiv(
-                        q.shape[2], META["BLOCK_M"]
-                    ),  # num_consumer_groups
+                    triton.cdiv(q.shape[2], META["BLOCK_M"]),  # num_consumer_groups
                     q.shape[0] * q.shape[1],
                     1,
                 )
@@ -1639,7 +1675,7 @@ class _attention_opt(torch.autograd.Function):
                 BATCH * H * N_CTX,
                 HEAD_DIM_Q,
                 META["BLOCK_M"]
-                // (2 if META['ENABLE_WS'] else 1),  # data partitioning: halve
+                // (2 if META["ENABLE_WS"] else 1),  # data partitioning: halve
                 HEAD_DIM_Q,
                 q.element_size(),
             )
@@ -1649,16 +1685,14 @@ class _attention_opt(torch.autograd.Function):
                 BATCH * H * N_CTX,
                 HEAD_DIM_Q,
                 META["BLOCK_M"]
-                // (2 if META['ENABLE_WS'] else 1),  # data partitioning: halve
+                // (2 if META["ENABLE_WS"] else 1),  # data partitioning: halve
                 HEAD_DIM_Q,
                 o.element_size(),
             )
             return (
                 # grid partitioning: num_consumer_groups * BLOCK_M
                 # data partitioning: BLOCK_M
-                triton.cdiv(
-                    q.shape[2], META["BLOCK_M"]
-                ),  # num_consumer_groups
+                triton.cdiv(q.shape[2], META["BLOCK_M"]),  # num_consumer_groups
                 q.shape[0] * q.shape[1],
                 1,
             )

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -55,9 +55,7 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 from torch.nn.functional import scaled_dot_product_attention as sdpa
 
 from tritonbench.kernels.triton_fused_attention import (
-    attention as triton_tutorial_FA2,
-    attention_tma as triton_tutorial_FA2_tma,
-    attention_ws as triton_tutorial_FA2_ws,
+    attention_opt as triton_tutorial_FA2_opt,
 )
 
 # [Optional] flash_attn v2
@@ -248,7 +246,18 @@ class Operator(BenchmarkOperator):
         k: torch.Tensor,
         v: torch.Tensor,
     ) -> Callable:
-        return lambda: triton_tutorial_FA2(q, k, v, self.causal, self.sm_scale)
+        # base: do not enable TMA/WarpSpec/CompPipe
+        return lambda: triton_tutorial_FA2_opt(q, k, v, self.causal, self.sm_scale, "base")
+
+    @register_benchmark(enabled=HAS_CUDA_124)
+    def triton_tutorial_flash_v2_opt(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> Callable:
+        # autotune CompPipe
+        return lambda: triton_tutorial_FA2_opt(q, k, v, self.causal, self.sm_scale, "opt")
 
     @register_benchmark(enabled=HAS_CUDA_124)
     def triton_tutorial_flash_v2_tma(
@@ -257,7 +266,8 @@ class Operator(BenchmarkOperator):
         k: torch.Tensor,
         v: torch.Tensor,
     ) -> Callable:
-        return lambda: triton_tutorial_FA2_tma(q, k, v, self.causal, self.sm_scale)
+        # autotune TMA/CompPipe
+        return lambda: triton_tutorial_FA2_opt(q, k, v, self.causal, self.sm_scale, "tma")
 
     @register_benchmark(enabled=HAS_CUDA_124)
     def triton_tutorial_flash_v2_ws(
@@ -266,7 +276,18 @@ class Operator(BenchmarkOperator):
         k: torch.Tensor,
         v: torch.Tensor,
     ) -> Callable:
-        return lambda: triton_tutorial_FA2_ws(q, k, v, self.causal, self.sm_scale)
+        # autotune WarpSpec/CompPipe
+        return lambda: triton_tutorial_FA2_opt(q, k, v, self.causal, self.sm_scale, "ws")
+
+    @register_benchmark(enabled=HAS_CUDA_124)
+    def triton_tutorial_flash_v2_tma_ws(
+        self,       
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> Callable:  
+        # autotune TMA/WarpSpec/CompPipe
+        return lambda: triton_tutorial_FA2_opt(q, k, v, self.causal, self.sm_scale, "tma_ws")
 
     @register_benchmark(enabled=HAS_KERNELS)
     def triton_op_flash_v2(


### PR DESCRIPTION
Variants:
- triton_tutorial_flash_v2_opt no TMA, with computation pipelining
- triton_tutorial_flash_v2_tma TMA, with computation pipelining
- triton_tutorial_flash_v2_tma_ws: TMA, with computation pipelining and Warp Spec
- triton_tutorial_flash_v2_ws: no TMA, with computation pipelining and Warp Spec

Test plan:
```
CUDA_VISIBLE_DEVICES=5 TORCH_CUDA_ARCH_LIST=9.0a python run.py --op flash_attention --only triton_tutorial_flash_v2_opt,triton_tutorial_flash_v2_tma,triton_tutorial_flash_v2 --num-inputs 1 --seq-len 13 --metrics tflops --batch 8 --n-heads 16 --d-head 128

CUDA_VISIBLE_DEVICES=5 TORCH_CUDA_ARCH_LIST=9.0a python run.py --op flash_attention --only triton_tutorial_flash_v2_opt,triton_tutorial_flash_v2_tma,triton_tutorial_flash_v2 --num-inputs 1 --seq-len 13 --metrics accuracy --batch 8 --n-heads 16 --d-head 128 --baseline triton_tutorial_flash_v2

On compiler supporting WarpSpec:
CUDA_VISIBLE_DEVICES=5 TORCH_CUDA_ARCH_LIST=9.0a python run.py --op flash_attention --only triton_tutorial_flash_v2_ws,triton_tutorial_flash_v2_tma_ws,triton_tutorial_flash_v2 --num-inputs 1 --seq-len 13 --metrics tflops --batch 8 --n-heads 16 --d-head 128
CUDA_VISIBLE_DEVICES=5 TORCH_CUDA_ARCH_LIST=9.0a python run.py --op flash_attention --only triton_tutorial_flash_v2_ws,triton_tutorial_flash_v2_tma_ws,triton_tutorial_flash_v2 --num-inputs 1 --seq-len 13 --metrics accuracy --batch 8 --n-heads 16 --d-head 128 --baseline triton_tutorial_flash_v2
```