### PR TITLE
Enable gemm and more operators in the CI

### DIFF
--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -25,6 +25,10 @@ fp8_gemm:
   - triton_persistent_fp8_gemm
   - triton_tma_persistent_fp8_gemm
 fp8_gemm_rowwise:
+gemm:
+  - triton_persistent_matmul
+  - triton_tma_persistent_matmul
+  - triton_tma_persistent_cached_matmul
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -31,6 +31,8 @@ gemm:
   - triton_tma_persistent_cached_matmul
   - hstu_triton_matmul
   - colfax_cutlass_matmul
+  # FIXME: PT2 CUTLASS backend failed
+  - pt2_cutlass_matmul
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -30,7 +30,7 @@ gemm:
   - triton_tma_persistent_matmul
   - triton_tma_persistent_cached_matmul
   - hstu_triton_matmul
-  - colfax_gemm
+  - colfax_cutlass_matmul
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -39,6 +39,11 @@ gemm:
   - colfax_cutlass_matmul
   # FIXME: PT2 CUTLASS backend failed
   - pt2_cutlass_matmul
+# jagged tests are slow, so disable them in OSS
+jagged_layer_norm:
+jagged_mean:
+jagged_softmax:
+jagged_sum:
 ragged_attention:
   - hstu_triton_ragged_attention_persistent
 test_op:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -29,6 +29,7 @@ gemm:
   - triton_persistent_matmul
   - triton_tma_persistent_matmul
   - triton_tma_persistent_cached_matmul
+  - hstu_triton_matmul
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -30,6 +30,7 @@ gemm:
   - triton_tma_persistent_matmul
   - triton_tma_persistent_cached_matmul
   - hstu_triton_matmul
+  - colfax_gemm
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -1,15 +1,19 @@
-# Tests we skip in OSS CI
-# This file is regarding to the Triton version bundled with pytorch
-# Use <op-name:> to skip an entire operator
-# Use <op-name:\n  - impl-name> to skip an impl
+# Tests we skip in triton-pytorch + OSS CI
+# triton-pytorch is the triton version bundled with pytorch nightly
+# We need to skip kernels that only work on triton-main
+# Usage:
+#  op-name: to skip an entire operator
+#  op-name:\n\t- impl-name to skip an impl
 bf16xint16_gemm:
   # LLVM ERROR: mma16816 data type not supported
   - bf16xint16
 flash_attention:
+  # FIXME: enable colfax_cutlass and tk
   - xformers
   - xformers_splitk
   - colfax_cutlass
   - tk
+  # triton_tutorial_* kernels require triton-main
   - triton_tutorial_flash_v2
   - triton_tutorial_flash_v2_opt
   - triton_tutorial_flash_v2_tma
@@ -17,16 +21,17 @@ flash_attention:
   - triton_tutorial_flash_v2_tma_ws
 fp8_attention:
   - colfax_fmha
-  # triton_flash_v2 now requires the main branch of Triton
-  # pytorch version does not work
+  # triton_flash_v2 requires triton-main
   - triton_flash_v2
-# All requires fb-import kernels
+# fp8_fused_quant_gemm_rowwise requires fb-only kernels
 fp8_fused_quant_gemm_rowwise:
 fp8_gemm:
+  # triton_*_persistent requires triton-main
   - triton_persistent_fp8_gemm
   - triton_tma_persistent_fp8_gemm
 fp8_gemm_rowwise:
 gemm:
+  # triton_*_persistent_* requires triton-main
   - triton_persistent_matmul
   - triton_tma_persistent_matmul
   - triton_tma_persistent_cached_matmul
@@ -34,10 +39,6 @@ gemm:
   - colfax_cutlass_matmul
   # FIXME: PT2 CUTLASS backend failed
   - pt2_cutlass_matmul
-jagged_layer_norm:
-jagged_mean:
-jagged_softmax:
-jagged_sum:
 ragged_attention:
   - hstu_triton_ragged_attention_persistent
 test_op:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -25,9 +25,6 @@ fp8_gemm:
   - triton_persistent_fp8_gemm
   - triton_tma_persistent_fp8_gemm
 fp8_gemm_rowwise:
-gemm:
-grouped_gemm:
-int4_gemm:
 jagged_layer_norm:
 jagged_mean:
 jagged_softmax:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -3,23 +3,24 @@
 # Use <op-name:> to skip an entire operator
 # Use <op-name:\n  - impl-name> to skip an impl
 bf16xint16_gemm:
+  # LLVM ERROR: mma16816 data type not supported
   - bf16xint16
-# TODO: we have many buggy backends for flash_attention
-# Need to fix them in the CI
 flash_attention:
-#   - triton_tutorial_flash_v2_tma
-#   - triton_op_flash_v2
-#   - xformers_splitk
-#   - colfax_cutlass
-#   - tk
-#   - sdpa
-#   - cudnn
-#   - flex_attention
+  - xformers
+  - xformers_splitk
+  - colfax_cutlass
+  - tk
+  - triton_tutorial_flash_v2
+  - triton_tutorial_flash_v2_opt
+  - triton_tutorial_flash_v2_tma
+  - triton_tutorial_flash_v2_ws
+  - triton_tutorial_flash_v2_tma_ws
 fp8_attention:
   - colfax_fmha
   # triton_flash_v2 now requires the main branch of Triton
   # pytorch version does not work
   - triton_flash_v2
+# All requires fb-import kernels
 fp8_fused_quant_gemm_rowwise:
 fp8_gemm:
   - triton_persistent_fp8_gemm

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -43,7 +43,7 @@ from tritonbench.utils.path_utils import add_ld_library_path, add_path, SUBMODUL
 from tritonbench.utils.triton_op import IS_FBCODE
 
 try:
-    with add_path(SUBMODULE_PATH.joinpath("kernels")):
+    with add_path(str(SUBMODULE_PATH.joinpath("kernels"))):
         from kernels.flash_attention import attention as triton_op_FA2
     HAS_KERNELS = True
 except BaseException:

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -1,10 +1,7 @@
 import argparse
 import csv
 import os
-import statistics
 from typing import Any, Callable, Generator, List, Optional, Tuple
-
-import numpy
 import torch
 import torch._inductor.config as inductor_config
 import triton
@@ -41,9 +38,8 @@ from .triton_matmul import (
     matmul_kernel as triton_tutorial_matmul_kernel,
 )
 
-if inductor_config.is_fbcode():
-    from hammer.ops.triton.triton_matmul import triton_matmul as hstu_triton_matmul
-
+if IS_FBCODE:
+    from hammer.ops.triton.triton_matmul import triton_matmul as hstu_triton_matmul_kernel
     HAS_HAMMER = True
 else:
     HAS_HAMMER = False
@@ -204,9 +200,9 @@ class Operator(BenchmarkOperator):
     @register_benchmark(enabled=HAS_HAMMER)
     def hstu_triton_matmul(self, a, b, bias) -> Callable:
         if not bias == None:
-            return lambda: hstu_triton_matmul(a, b) + bias
+            return lambda: hstu_triton_matmul_kernel(a, b) + bias
         else:
-            return lambda: hstu_triton_matmul(a, b)
+            return lambda: hstu_triton_matmul_kernel(a, b)
 
     @register_benchmark(enabled=bool(colfax_gemm))
     def colfax_cutlass_matmul(self, a, b, bias) -> Callable:

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -24,12 +24,14 @@ from tritonbench.utils.triton_op import (
 
 from .kernels import matmul as kernels
 from .partition_k import matmul_partition_k
+
 try:
     from .persistent_matmul import (
         matmul_persistent,
         matmul_tma_persistent,
         matmul_tma_persistent_cached,
     )
+
     HAS_PRESISTENT = True
 except ModuleNotFoundError:
     HAS_PRESISTENT = False

--- a/tritonbench/operators/gemm/operator.py
+++ b/tritonbench/operators/gemm/operator.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import os
 from typing import Any, Callable, Generator, List, Optional, Tuple
+
 import torch
 import torch._inductor.config as inductor_config
 import triton
@@ -39,7 +40,10 @@ from .triton_matmul import (
 )
 
 if IS_FBCODE:
-    from hammer.ops.triton.triton_matmul import triton_matmul as hstu_triton_matmul_kernel
+    from hammer.ops.triton.triton_matmul import (
+        triton_matmul as hstu_triton_matmul_kernel,
+    )
+
     HAS_HAMMER = True
 else:
     HAS_HAMMER = False


### PR DESCRIPTION
As the test isolation is implemented in https://github.com/pytorch-labs/tritonbench/pull/55, we can now enable more operators in the CI.