### PR TITLE
Use code detection to check bwd method override.

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -88,9 +88,9 @@ def _run_operator_in_task(op: str, args: List[str]):
     task.make_operator_instance(args=args)
     task.run()
     task.check_output()
-    task.del_op_instance()
     # Test backward (if applicable)
     if task.get_attribute("has_bwd"):
+        task.del_op_instance()
         args.extend(["--bwd"])
         task.make_operator_instance(args=args)
         task.run()

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -68,7 +68,7 @@ def _run_one_operator(args: List[str]):
     check_ci_output(op)
     del op
     # Test backward (if applicable)
-    if op.has_bwd:
+    if op.has_bwd():
         tb_args.mode = "bwd"
         op = Operator(tb_args=tb_args, extra_args=extra_args)
         op.run()
@@ -89,7 +89,7 @@ def _run_operator_in_task(op: str, args: List[str]):
     task.run()
     task.check_output()
     # Test backward (if applicable)
-    if task.get_attribute("has_bwd"):
+    if task.get_attribute("has_bwd", method=True):
         task.del_op_instance()
         args.extend(["--bwd"])
         task.make_operator_instance(args=args)

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -68,15 +68,11 @@ def _run_one_operator(args: List[str]):
     check_ci_output(op)
     del op
     # Test backward (if applicable)
-    try:
+    if op.has_bwd:
         tb_args.mode = "bwd"
         op = Operator(tb_args=tb_args, extra_args=extra_args)
         op.run()
         check_ci_output(op)
-    except NotImplementedError:
-        logger.info(
-            f"Operator {op.name} does not support backward, skipping backward test."
-        )
 
 
 def _run_operator_in_task(op: str, args: List[str]):
@@ -94,14 +90,11 @@ def _run_operator_in_task(op: str, args: List[str]):
     task.check_output()
     task.del_op_instance()
     # Test backward (if applicable)
-    try:
+    if task.get_attribute("has_bwd"):
         args.extend(["--bwd"])
         task.make_operator_instance(args=args)
         task.run()
         task.check_output()
-    except NotImplementedError:
-        # Operator does not support backward, skip the test
-        pass
 
 
 def make_test(operator):

--- a/tritonbench/operators/op_task.py
+++ b/tritonbench/operators/op_task.py
@@ -165,7 +165,10 @@ class OpTask(base_task.TaskBase):
     @base_task.run_in_worker(scoped=True)
     @staticmethod
     def get_attribute(
-        attr: str, field: Optional[str] = None, classattr: bool = False
+        attr: str,
+        field: Optional[str] = None,
+        classattr: bool = False,
+        method: bool = False,
     ) -> Any:
         if classattr:
             op = globals()["Operator"]
@@ -173,10 +176,10 @@ class OpTask(base_task.TaskBase):
             op = globals()["op"]
         if hasattr(op, attr):
             if field:
-                op_attr = getattr(op, attr)
-                return getattr(op_attr, field)
+                op_attr = getattr(getattr(op, attr), field)
             else:
-                return getattr(op, attr)
+                op_attr = getattr(op, attr)
+            return op_attr() if method else op_attr
         else:
             return None
 

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1517,3 +1517,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     ir_dir / f"{fn._name}_{kernel.name}_{input_id}.sass", "w"
                 ) as f:
                     f.write(sass)
+
+    @property
+    def has_bwd(self) -> bool:
+        return self.get_bwd_fn.__code__ is BenchmarkOperator.get_bwd_fn.__code__

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1518,6 +1518,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 ) as f:
                     f.write(sass)
 
-    @property
-    def has_bwd(self) -> bool:
-        return self.get_bwd_fn.__code__ is BenchmarkOperator.get_bwd_fn.__code__
+    @classmethod
+    def has_bwd(cls) -> bool:
+        return cls.get_bwd_fn is not BenchmarkOperator.get_bwd_fn


### PR DESCRIPTION
We can use a smarter way to detect whether an operator has implemented backward. This can help speedup the unit test.