### PR TITLE
Fix backends in flash_attention and gemm

### DIFF
--- a/.ci/tritonbench/test-gpu.sh
+++ b/.ci/tritonbench/test-gpu.sh
@@ -8,8 +8,11 @@ fi
 
 . "${SETUP_SCRIPT}"
 
-# FIXME: patch hstu
+# FIXME: patch and install hstu
 sudo apt-get install  -y patch
 python install.py --hstu
+
+# FIXME: install colfax
+python install.py --colfax
 
 python -m unittest test.test_gpu.main -v

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/xformers"]
 	path = submodules/xformers
 	url = https://github.com/facebookresearch/xformers.git
+[submodule "submodules/cutlass"]
+	path = submodules/cutlass
+	url = https://github.com/NVIDIA/cutlass.git

--- a/install.py
+++ b/install.py
@@ -52,12 +52,6 @@ def test_fbgemm():
     print("OK")
 
 
-def install_cutlass():
-    from tools.cutlass_kernels.install import install_colfax_cutlass
-
-    install_colfax_cutlass()
-
-
 def install_fa2(compile=False):
     if compile:
         # compile from source (slow)
@@ -83,12 +77,6 @@ def install_liger():
     subprocess.check_call(cmd)
 
 
-def install_tk():
-    from tools.tk.install import install_tk
-
-    install_tk()
-
-
 def install_xformers():
     os_env = os.environ.copy()
     os_env["TORCH_CUDA_ARCH_LIST"] = "8.0;9.0;9.0a"
@@ -101,7 +89,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument("--fbgemm", action="store_true", help="Install FBGEMM GPU")
     parser.add_argument(
-        "--cutlass", action="store_true", help="Install optional CUTLASS kernels"
+        "--colfax", action="store_true", help="Install optional Colfax CUTLASS kernels"
     )
     parser.add_argument(
         "--fa2", action="store_true", help="Install optional flash_attention 2 kernels"
@@ -139,14 +127,16 @@ if __name__ == "__main__":
     if args.fa3 or args.all:
         logger.info("[tritonbench] installing fa3...")
         install_fa3()
-    if args.cutlass or args.all:
-        logger.info("[tritonbench] installing cutlass-kernels...")
-        install_cutlass()
+    if args.colfax or args.all:
+        logger.info("[tritonbench] installing colfax cutlass-kernels...")
+        from tools.cutlass_kernels.install import install_colfax_cutlass
+        install_colfax_cutlass()
     if args.jax or args.all:
         logger.info("[tritonbench] installing jax...")
         install_jax()
     if args.tk or args.all:
         logger.info("[tritonbench] installing thunderkittens...")
+        from tools.tk.install import install_tk
         install_tk()
     if args.liger or args.all:
         logger.info("[tritonbench] installing liger-kernels...")

--- a/install.py
+++ b/install.py
@@ -130,6 +130,7 @@ if __name__ == "__main__":
     if args.colfax or args.all:
         logger.info("[tritonbench] installing colfax cutlass-kernels...")
         from tools.cutlass_kernels.install import install_colfax_cutlass
+
         install_colfax_cutlass()
     if args.jax or args.all:
         logger.info("[tritonbench] installing jax...")
@@ -137,6 +138,7 @@ if __name__ == "__main__":
     if args.tk or args.all:
         logger.info("[tritonbench] installing thunderkittens...")
         from tools.tk.install import install_tk
+
         install_tk()
     if args.liger or args.all:
         logger.info("[tritonbench] installing liger-kernels...")

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -8,11 +8,6 @@ bf16xint16_gemm:
   # LLVM ERROR: mma16816 data type not supported
   - bf16xint16
 flash_attention:
-  # FIXME: enable colfax_cutlass and tk
-  - xformers
-  - xformers_splitk
-  - colfax_cutlass
-  - tk
   # triton_tutorial_* kernels require triton-main
   - triton_tutorial_flash_v2
   - triton_tutorial_flash_v2_opt

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -8,6 +8,8 @@ bf16xint16_gemm:
   # LLVM ERROR: mma16816 data type not supported
   - bf16xint16
 flash_attention:
+  # thunderkittens cannot handle the default input shapes
+  - tk
   # triton_tutorial_* kernels require triton-main
   - triton_tutorial_flash_v2
   - triton_tutorial_flash_v2_opt

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -37,8 +37,6 @@ gemm:
   - triton_tma_persistent_cached_matmul
   - hstu_triton_matmul
   - colfax_cutlass_matmul
-  # FIXME: PT2 CUTLASS backend failed
-  - pt2_cutlass_matmul
 # jagged tests are slow, so disable them in OSS
 jagged_layer_norm:
 jagged_mean:

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -42,3 +42,5 @@ jagged_sum:
 ragged_attention:
   - hstu_triton_ragged_attention_persistent
 test_op:
+fwd_only_ops:
+  - flash_attention

--- a/tools/cutlass_kernels/install.py
+++ b/tools/cutlass_kernels/install.py
@@ -8,8 +8,7 @@ CUDA_HOME = (
     "/usr/local/cuda" if "CUDA_HOME" not in os.environ else os.environ["CUDA_HOME"]
 )
 REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
-FBGEMM_PATH = REPO_PATH.joinpath("submodules", "FBGEMM", "fbgemm_gpu")
-FBGEMM_CUTLASS_PATH = FBGEMM_PATH.parent.joinpath("external", "cutlass")
+TORCH_CUTLASS_PATH = REPO_PATH.joinpath("submodules", "cutlass")
 COLFAX_CUTLASS_PATH = REPO_PATH.joinpath("submodules", "cutlass-kernels")
 COLFAX_CUTLASS_TRITONBENCH_PATH = REPO_PATH.joinpath("tools", "cutlass_kernels")
 
@@ -41,9 +40,9 @@ COMPILER_FLAGS = [
     f"-I{str(COLFAX_CUTLASS_PATH.joinpath('lib').resolve())}",
     f"-I{str(COLFAX_CUTLASS_PATH.joinpath('include').resolve())}",
     f"-I{str(COLFAX_CUTLASS_PATH.joinpath('src', 'fmha').resolve())}",
-    f"-I{str(FBGEMM_CUTLASS_PATH.joinpath('include').resolve())}",
-    f"-I{str(FBGEMM_CUTLASS_PATH.joinpath('examples', 'commmon').resolve())}",
-    f"-I{str(FBGEMM_CUTLASS_PATH.joinpath('tools', 'util', 'include').resolve())}",
+    f"-I{str(TORCH_CUTLASS_PATH.joinpath('include').resolve())}",
+    f"-I{str(TORCH_CUTLASS_PATH.joinpath('examples', 'commmon').resolve())}",
+    f"-I{str(TORCH_CUTLASS_PATH.joinpath('tools', 'util', 'include').resolve())}",
     f"-I{CUDA_HOME}/include",
     f"-I{str(TORCH_BASE_PATH.joinpath('include').resolve())}",
     f"-I{str(COLFAX_CUTLASS_TRITONBENCH_PATH.joinpath('include').resolve())}",

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -92,7 +92,8 @@ try:
     import xformers.ops.fmha as xformers_fmha  # @manual=//fair/xformers:xformers
 
     from .test_fmha_utils import permute_qkv
-    HAS_XFORMERS =True
+
+    HAS_XFORMERS = True
 except (ImportError, IOError, AttributeError):
     HAS_XFORMERS = False
 

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -377,10 +377,10 @@ class Operator(BenchmarkOperator):
     @register_benchmark(enabled=bool(tk_fwd is not None))
     def tk(self, q, k, v):
         o = torch.zeros_like(v)
-        l = torch.zeros_like(o).to(torch.float32)
+        l_tensor = torch.zeros_like(o).to(torch.float32)
 
         def tk_dispatcher():
-            tk_fwd.attention_forward(q, k, v, o, l, causal=self.causal)
+            tk_fwd.attention_forward(q, k, v, o, l_tensor, causal=self.causal)
             return o
 
         return tk_dispatcher

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -122,7 +122,6 @@ try:
         tk_fwd = torch.ops.tk
 except (ImportError, IOError, AttributeError):
     tk_fwd = None
-    tk_fwd_causal = None
 
 from typing import Any, Generator, List
 
@@ -381,12 +380,10 @@ class Operator(BenchmarkOperator):
     @register_benchmark(enabled=bool(tk_fwd is not None))
     def tk(self, q, k, v):
         o = torch.zeros_like(v)
+        l = torch.zeros_like(o).to(torch.float32)
 
         def tk_dispatcher():
-            if self.causal:
-                tk_fwd_causal.attention_forward_causal(q, k, v, o)
-            else:
-                tk_fwd.attention_forward(q, k, v, o)
+            tk_fwd.attention_forward(q, k, v, o, l, causal=self.causal)
             return o
 
         return tk_dispatcher

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -144,9 +144,6 @@ def parse_op_args(args: List[str]):
     parser.add_argument("--n-heads", type=int, default=48, help="Number of heads")
     parser.add_argument("--d-head", type=int, default=64, help="specify head dimension")
     parser.add_argument("--causal", action="store_true", help="enable causal")
-    parser.add_argument(
-        "--xformers-splitk", action="store_true", help="benchmark xformers-split impl"
-    )
     return parser.parse_args(args)
 
 
@@ -167,7 +164,6 @@ class Operator(BenchmarkOperator):
         self.N_CTX = None
         self.causal = args.causal
         self.sm_scale = 1.3
-        self.xformers_splitk = args.xformers_splitk
 
     @register_benchmark()
     def aten(

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -26,7 +26,7 @@ AVAILABLE_PRECISIONS = [
 
 def set_env():
     # set cutlass dir
-    # by default we use the cutlass version built with fbgemm
+    # by default we use the cutlass version built with pytorch
     import torch
 
     current_cutlass_dir = torch._inductor.config.cuda.cutlass_dir

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -24,13 +24,13 @@ AVAILABLE_PRECISIONS = [
 
 
 def set_env():
-    import torch
-    IS_FBCODE = not hasattr(torch.version, "git_version")
     # set cutlass dir
     # by default we use the cutlass version built with fbgemm
-    if not "TORCHINDUCTOR_CUTLASS_DIR" in os.environ and not IS_FBCODE:
-        cutlass_dir = REPO_PATH.joinpath("submodules", "FBGEMM", "external", "cutlass")
-        os.environ["TORCHINDUCTOR_CUTLASS_DIR"] = str(cutlass_dir.absolute())
+    import torch
+    current_cutlass_dir = torch._inductor.config.cuda.cutlass_dir
+    if not os.path.exists(current_cutlass_dir):
+        tb_cutlass_dir = REPO_PATH.joinpath("submodules", "cutlass")
+        torch._inductor.config.cuda.cutlass_dir = str(tb_cutlass_dir)
 
 
 def set_random_seed():

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -4,6 +4,7 @@ import shutil
 from contextlib import contextmanager, ExitStack
 
 from typing import Optional
+from tritonbench.utils.path_utils import REPO_PATH
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +21,16 @@ AVAILABLE_PRECISIONS = [
     "amp_bf16",
     "fp8",
 ]
+
+
+def set_env():
+    import torch
+    IS_FBCODE = not hasattr(torch.version, "git_version")
+    # set cutlass dir
+    # by default we use the cutlass version built with fbgemm
+    if not "TORCHINDUCTOR_CUTLASS_DIR" in os.environ and not IS_FBCODE:
+        cutlass_dir = REPO_PATH.joinpath("submodules", "FBGEMM", "external", "cutlass")
+        os.environ["TORCHINDUCTOR_CUTLASS_DIR"] = str(cutlass_dir.absolute())
 
 
 def set_random_seed():

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -30,7 +30,8 @@ def set_env():
     current_cutlass_dir = torch._inductor.config.cuda.cutlass_dir
     if not os.path.exists(current_cutlass_dir):
         tb_cutlass_dir = REPO_PATH.joinpath("submodules", "cutlass")
-        torch._inductor.config.cuda.cutlass_dir = str(tb_cutlass_dir)
+        if tb_cutlass_dir.is_dir():
+            torch._inductor.config.cuda.cutlass_dir = str(tb_cutlass_dir)
 
 
 def set_random_seed():

--- a/tritonbench/utils/env_utils.py
+++ b/tritonbench/utils/env_utils.py
@@ -4,6 +4,7 @@ import shutil
 from contextlib import contextmanager, ExitStack
 
 from typing import Optional
+
 from tritonbench.utils.path_utils import REPO_PATH
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def set_env():
     # set cutlass dir
     # by default we use the cutlass version built with fbgemm
     import torch
+
     current_cutlass_dir = torch._inductor.config.cuda.cutlass_dir
     if not os.path.exists(current_cutlass_dir):
         tb_cutlass_dir = REPO_PATH.joinpath("submodules", "cutlass")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -621,7 +621,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def _get_bm_func(self, bm_func_name: str):
         fwd_fn_lambda = getattr(self, bm_func_name, None)
-        assert fwd_fn_lambda, (
+        assert callable(fwd_fn_lambda), (
             f"Could not find benchmark {bm_func_name} registered in {self.name}. "
             f"Available benchmarks: {REGISTERED_BENCHMARKS[self.name].keys()}. "
         )

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -27,6 +27,7 @@ from tritonbench.utils.env_utils import (
     apply_precision,
     fresh_triton_cache,
     set_random_seed,
+    set_env,
 )
 from tritonbench.utils.input import input_cast
 
@@ -561,6 +562,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
     ):
+        set_env()
         set_random_seed()
         self.name = _find_op_name_from_module_path(self.__class__.__module__)
         self._raw_extra_args = copy.deepcopy(extra_args)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -26,8 +26,8 @@ from tritonbench.components.ncu import analyzer as ncu_analyzer
 from tritonbench.utils.env_utils import (
     apply_precision,
     fresh_triton_cache,
-    set_random_seed,
     set_env,
+    set_random_seed,
 )
 from tritonbench.utils.input import input_cast
 


### PR DESCRIPTION
To run PT2 cutlass backend, we have to add a cutlass submodule that has the same version as pytorch: https://github.com/pytorch/pytorch/tree/main/third_party

The version points to 
https://github.com/NVIDIA/cutlass/tree/bbe579a9e3beb6ea6626d9227ec32d0dae119a49 which is 9 months old.
The FBGEMM cutlass is much newer.

Test plan:

```
$ python run.py --op gemm --mode fwd --only pt2_cutlass_matmul --num-inputs 1
      (M, N, K)    pt2_cutlass_matmul-speedup    pt2_cutlass_matmul-tflops    pt2_cutlass_matmul-gbps
---------------  ----------------------------  ---------------------------  -------------------------
(256, 256, 256)                                                    3.51871                    41.2349
```

Fixes https://github.com/pytorch-labs/tritonbench/issues/17