### PR TITLE
Install patch in the docker

### DIFF
--- a/.ci/tritonbench/install-triton-main.sh
+++ b/.ci/tritonbench/install-triton-main.sh
@@ -28,5 +28,17 @@ conda activate "${CONDA_ENV}"
 cd /workspace
 git clone https://github.com/triton-lang/triton.git
 cd /workspace/triton
+# delete the original triton directory
+TRITON_PKG_DIR=$(python -c "import triton; import os; print(os.path.dirname(triton.__file__))")
+# make sure all pytorch triton has been uninstalled
+pip uninstall -y triton
+pip uninstall -y triton
+pip uninstall -y triton
+rm -rf "${TRITON_PKG_DIR}"
+
+# install main triton
 pip install ninja cmake wheel pybind11; # build-time dependencies
 pip install -e python
+
+# test main branch installation with importing experimental descriptor
+python -c "import triton.tools.experimental_descriptor"

--- a/.ci/tritonbench/test-gpu.sh
+++ b/.ci/tritonbench/test-gpu.sh
@@ -8,11 +8,4 @@ fi
 
 . "${SETUP_SCRIPT}"
 
-# FIXME: patch and install hstu
-sudo apt-get install  -y patch
-python install.py --hstu
-
-# FIXME: install colfax
-python install.py --colfax
-
 python -m unittest test.test_gpu.main -v

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -44,7 +44,7 @@ RUN cd /workspace/tritonbench && \
 
 # Tritonbench library build and test require libcuda.so.1
 # which is from NVIDIA driver
-RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf
+RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf patch
 
 # Install Tritonbench
 RUN cd /workspace/tritonbench && \

--- a/tools/cuda_utils.py
+++ b/tools/cuda_utils.py
@@ -129,6 +129,12 @@ def install_torch_deps(cuda_version: str):
     ]
     cmd = ["conda", "install", "-y"] + torch_deps
     subprocess.check_call(cmd)
+    # conda forge deps
+    # ubuntu 22.04 comes with libstdcxx6 12.3.0
+    # we need to install the same library version in conda
+    conda_deps = ["libstdcxx-ng=12.3.0"]
+    cmd = ["conda", "install", "-y", "-c", "conda-forge"] + conda_deps
+    subprocess.check_call(cmd)
 
 
 def install_torch_build_deps(cuda_version: str):


### PR DESCRIPTION
Now we have to patch third-party submodules like hstu and xformers, install the patch utility to the CI docker.

Test Plan:
CI

https://github.com/pytorch-labs/tritonbench/actions/runs/11946317137