### PR TITLE
Support sparsity, target-size and sort_by_length for hstu

### DIFF
--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -48,6 +48,7 @@ class RaggedHSTUAttn(torch.nn.Module):
         num_buckets,
         sparsity,
         target_size,
+        sort_by_length,
         requires_grad,
         persistent_kernel: bool = False,
     ) -> None:
@@ -58,6 +59,7 @@ class RaggedHSTUAttn(torch.nn.Module):
         self.num_buckets = num_buckets
         self.sparsity = sparsity
         self.target_size = target_size
+        self.sort_by_length = sort_by_length
         self.all_ts_weights = torch.nn.Parameter(
             torch.randn(
                 (self.num_buckets + 1,),
@@ -175,7 +177,7 @@ class RaggedHSTUAttn(torch.nn.Module):
                 kwargs["ATTN_BIAS_TYPE"],  # relative_bias_type
                 kwargs["MAX_ATTN_LEN"],  # max_attn_len
                 kwargs["CONTEXTUAL_SEQ_LEN"],  # contextual_seq_len
-                kwargs["sort_by_length_indices"],  # sort_by_length
+                self.sort_by_length,
             )
 
         return out
@@ -213,7 +215,7 @@ def generate_sparse_seq_len(
 
 
 def get_test_inputs(
-    batch_size, num_heads, max_seq_len, sparsity, target_size, requires_grad
+    batch_size, num_heads, max_seq_len, sparsity, target_size, sort_by_length, requires_grad
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     timestamp_deltas: torch.Tensor = torch.randint(
         86400,

--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -79,7 +79,11 @@ class RaggedHSTUAttn(torch.nn.Module):
         self.persistent_kernel = persistent_kernel
 
     def forward(
-        self, qkv: torch.Tensor, seq_offsets: torch.Tensor, timestamps: torch.Tensor, num_targets: torch.Tensor
+        self,
+        qkv: torch.Tensor,
+        seq_offsets: torch.Tensor,
+        timestamps: torch.Tensor,
+        num_targets: torch.Tensor,
     ) -> torch.Tensor:
         NUM_BUCKETS = self.num_buckets
         torch._check(timestamps.size(0) + 1 == seq_offsets.size(0))
@@ -215,7 +219,13 @@ def generate_sparse_seq_len(
 
 
 def get_test_inputs(
-    batch_size, num_heads, max_seq_len, sparsity, target_size, sort_by_length, requires_grad
+    batch_size,
+    num_heads,
+    max_seq_len,
+    sparsity,
+    target_size,
+    sort_by_length,
+    requires_grad,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     timestamp_deltas: torch.Tensor = torch.randint(
         86400,

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -64,7 +64,9 @@ class Operator(BenchmarkOperator):
 
     # TODO: enable persistent kernels when the OSS backward is ready
     @register_benchmark(enabled=False)
-    def hstu_triton_ragged_attention_persistent(self, qkv, seq_offsets, timestamps, num_targets):
+    def hstu_triton_ragged_attention_persistent(
+        self, qkv, seq_offsets, timestamps, num_targets
+    ):
         attn = RaggedHSTUAttn(
             self.batch_size,
             self.num_heads,
@@ -79,12 +81,26 @@ class Operator(BenchmarkOperator):
         return lambda: attn(qkv, seq_offsets, timestamps, num_targets)
 
     def get_x_val(self, example_inputs):
-        return (self.batch_size, self.num_heads, self.max_seq_len, self.num_buckets, self.sparsity, self.target_size, self.sort_by_length)
+        return (
+            self.batch_size,
+            self.num_heads,
+            self.max_seq_len,
+            self.num_buckets,
+            self.sparsity,
+            self.target_size,
+            self.sort_by_length,
+        )
 
     def get_input_iter(self):
         for _input_id in range(self._num_inputs):
             inputs = get_test_inputs(
-                self.batch_size, self.num_heads, self.max_seq_len, self.sparsity, self.target_size, self.sort_by_length, self.requires_grad
+                self.batch_size,
+                self.num_heads,
+                self.max_seq_len,
+                self.sparsity,
+                self.target_size,
+                self.sort_by_length,
+                self.requires_grad,
             )
             yield inputs
 

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -24,6 +24,7 @@ def parse_op_args(args: List[str]):
     parser.add_argument("--num-buckets", type=int, default=2048)
     parser.add_argument("--sparsity", type=float, default=0.8)
     parser.add_argument("--target-size", type=int, default=20)
+    parser.add_argument("--sort-by-length", type=bool, default=False)
     return parser.parse_args(args)
 
 
@@ -41,6 +42,7 @@ class Operator(BenchmarkOperator):
         self.num_buckets = args.num_buckets
         self.sparsity = args.sparsity
         self.target_size = args.target_size
+        self.sort_by_length = args.sort_by_length
         # set a default number of inputs
         self._num_inputs = 10 if self._num_inputs is None else self._num_inputs
         self.requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
@@ -54,6 +56,7 @@ class Operator(BenchmarkOperator):
             self.num_buckets,
             self.sparsity,
             self.target_size,
+            self.sort_by_length,
             self.requires_grad,
             persistent_kernel=False,
         )
@@ -69,18 +72,19 @@ class Operator(BenchmarkOperator):
             self.num_buckets,
             self.sparsity,
             self.target_size,
+            self.sort_by_length,
             self.requires_grad,
             persistent_kernel=True,
         )
         return lambda: attn(qkv, seq_offsets, timestamps, num_targets)
 
     def get_x_val(self, example_inputs):
-        return (self.batch_size, self.num_heads, self.max_seq_len, self.num_buckets, self.sparsity, self.target_size)
+        return (self.batch_size, self.num_heads, self.max_seq_len, self.num_buckets, self.sparsity, self.target_size, self.sort_by_length)
 
     def get_input_iter(self):
         for _input_id in range(self._num_inputs):
             inputs = get_test_inputs(
-                self.batch_size, self.num_heads, self.max_seq_len, self.sparsity, self.target_size, self.requires_grad
+                self.batch_size, self.num_heads, self.max_seq_len, self.sparsity, self.target_size, self.sort_by_length, self.requires_grad
             )
             yield inputs
 

--- a/tritonbench/operators/ragged_attention/operator.py
+++ b/tritonbench/operators/ragged_attention/operator.py
@@ -22,7 +22,7 @@ def parse_op_args(args: List[str]):
     parser.add_argument("--heads", type=int, default=4, help="Number of heads")
     parser.add_argument("--max-seq-len-log2", type=int, default=9)
     parser.add_argument("--num-buckets", type=int, default=2048)
-    parser.add_argument("--sparsity", type=float, default=0.8)
+    parser.add_argument("--seq-sparsity", type=float, default=0.8)
     parser.add_argument("--target-size", type=int, default=20)
     parser.add_argument("--sort-by-length", type=bool, default=False)
     return parser.parse_args(args)
@@ -40,7 +40,7 @@ class Operator(BenchmarkOperator):
         self.num_heads = args.heads
         self.max_seq_len = 2**args.max_seq_len_log2
         self.num_buckets = args.num_buckets
-        self.sparsity = args.sparsity
+        self.sparsity = args.seq_sparsity
         self.target_size = args.target_size
         self.sort_by_length = args.sort_by_length
         # set a default number of inputs


### PR DESCRIPTION
Copied over generate_sparse_seq_len
Example output
                                x_val    hstu_triton_ragged_attention-latency
-------------------------------------  --------------------------------------
(256, 4, 16384, 2048, 0.8, 20, False)                                 146.458
(256, 4, 16384, 2048, 0.8, 20, False)                                 148.616
(256, 4, 16384, 2048, 0.8, 20, False)                                 145.135
(256, 4, 16384, 2048, 0.8, 20, False)                                 148.98
(256, 4, 16384, 2048, 0.8, 20, False)                                 147.167
(256, 4, 16384, 2048, 0.8, 20, False)                                 146.155
(256, 4, 16384, 2048, 0.8, 20, False)                                 144.787
(256, 4, 16384, 2048, 0.8, 20, False)                                 144.055
(256, 4, 16384, 2048, 0.8, 20, False)                                 144.35
(256, 4, 16384, 2048, 0.8, 20, False)                                 146.67