### PR TITLE
Enable bwd for flash_attention

### DIFF
--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -43,11 +43,16 @@ TEST_OPERATORS = set(list_operators_by_collection(op_collection="default"))
 
 
 def check_ci_output(op):
-    from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS, find_enabled_benchmarks
+    from tritonbench.utils.triton_op import (
+        find_enabled_benchmarks,
+        REGISTERED_BENCHMARKS,
+    )
 
     output = op.output
     output_impls = output.result[0][1].keys()
-    ci_enabled_impls = find_enabled_benchmarks(op.mode, REGISTERED_BENCHMARKS[op.name], op._skip)
+    ci_enabled_impls = find_enabled_benchmarks(
+        op.mode, REGISTERED_BENCHMARKS[op.name], op._skip
+    )
     # Make sure that all the ci_enabled impls are in the output
     logger.info(f"output impls: {output_impls}, ci_enabled impls: {ci_enabled_impls}")
     assert set(output_impls) == set(

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -43,13 +43,11 @@ TEST_OPERATORS = set(list_operators_by_collection(op_collection="default"))
 
 
 def check_ci_output(op):
-    from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS
+    from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS, find_enabled_benchmarks
 
     output = op.output
     output_impls = output.result[0][1].keys()
-    ci_enabled_impls = [
-        x for x in REGISTERED_BENCHMARKS[output.op_name].keys() if x not in op._skip
-    ]
+    ci_enabled_impls = find_enabled_benchmarks(op.mode, REGISTERED_BENCHMARKS[op.name], op._skip)
     # Make sure that all the ci_enabled impls are in the output
     logger.info(f"output impls: {output_impls}, ci_enabled impls: {ci_enabled_impls}")
     assert set(output_impls) == set(

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -43,5 +43,3 @@ jagged_sum:
 ragged_attention:
   - hstu_triton_ragged_attention_persistent
 test_op:
-fwd_only_ops:
-  - flash_attention

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -36,5 +36,3 @@ jagged_sum:
 # FIXME: ragged attention will Abort (Core Dump) on Triton Main
 ragged_attention:
 test_op:
-fwd_only_ops:
-  - flash_attention

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -1954,7 +1954,7 @@ class _attention_opt(torch.autograd.Function):
             num_stages=NUM_STAGES,  #
         )
 
-        return dq, dk, dv, None, None
+        return dq, dk, dv, None, None, None
 
 
 attention_opt = _attention_opt.apply

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -345,7 +345,7 @@ class Operator(BenchmarkOperator):
             fhma_input, needs_gradient=need_gradient
         )
 
-    @register_benchmark(enabled=HAS_XFORMERS)
+    @register_benchmark(enabled=HAS_XFORMERS, fwd_only=True)
     def xformers_splitk(
         self,
         q: torch.Tensor,

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -341,7 +341,9 @@ class Operator(BenchmarkOperator):
         need_gradient = not (self.mode == BenchmarkMode.FWD_NO_GRAD)
         fhma_input = self.xformers_preprocess(q, k, v)
         xformers_cutlass_fhma = xformers.ops.fmha.cutlass.FwOp
-        return lambda: xformers_cutlass_fhma().apply(fhma_input, needs_gradient=need_gradient)
+        return lambda: xformers_cutlass_fhma().apply(
+            fhma_input, needs_gradient=need_gradient
+        )
 
     @register_benchmark(enabled=HAS_XFORMERS)
     def xformers_splitk(
@@ -353,7 +355,9 @@ class Operator(BenchmarkOperator):
         need_gradient = not (self.mode == BenchmarkMode.FWD_NO_GRAD)
         fhma_input = self.xformers_preprocess(q, k, v)
         xformers_splitk_fhma = xformers_fmha.triton_splitk.FwOp
-        return lambda: xformers_splitk_fhma().apply(fhma_input, needs_gradient=need_gradient)
+        return lambda: xformers_splitk_fhma().apply(
+            fhma_input, needs_gradient=need_gradient
+        )
 
     def colfax_cutlass_preprocess(self, q, k, v):
         return (

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -448,6 +448,9 @@ class Operator(BenchmarkOperator):
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         o = fwd_fn()
+        # xformers_splitk does not have backward
+        if fwd_fn._name == "xformers_splitk":
+            raise NotImplementedError("xformers split-k does not support backward")
         o_tensor = input_filter(
             lambda x: isinstance(x, torch.Tensor),
             o,

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -338,9 +338,10 @@ class Operator(BenchmarkOperator):
         k: torch.Tensor,
         v: torch.Tensor,
     ) -> Callable:
+        need_gradient = not (self.mode == BenchmarkMode.FWD_NO_GRAD)
         fhma_input = self.xformers_preprocess(q, k, v)
         xformers_cutlass_fhma = xformers.ops.fmha.cutlass.FwOp
-        return lambda: xformers_cutlass_fhma().apply(fhma_input, needs_gradient=False)
+        return lambda: xformers_cutlass_fhma().apply(fhma_input, needs_gradient=need_gradient)
 
     @register_benchmark(enabled=HAS_XFORMERS)
     def xformers_splitk(
@@ -349,9 +350,10 @@ class Operator(BenchmarkOperator):
         k: torch.Tensor,
         v: torch.Tensor,
     ):
+        need_gradient = not (self.mode == BenchmarkMode.FWD_NO_GRAD)
         fhma_input = self.xformers_preprocess(q, k, v)
         xformers_splitk_fhma = xformers_fmha.triton_splitk.FwOp
-        return lambda: xformers_splitk_fhma().apply(fhma_input, needs_gradient=False)
+        return lambda: xformers_splitk_fhma().apply(fhma_input, needs_gradient=need_gradient)
 
     def colfax_cutlass_preprocess(self, q, k, v):
         return (

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -448,9 +448,6 @@ class Operator(BenchmarkOperator):
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         o = fwd_fn()
-        # xformers_splitk does not have backward
-        if fwd_fn._name == "xformers_splitk":
-            raise NotImplementedError("xformers split-k does not support backward")
         o_tensor = input_filter(
             lambda x: isinstance(x, torch.Tensor),
             o,

--- a/tritonbench/operators/op_task.py
+++ b/tritonbench/operators/op_task.py
@@ -190,11 +190,16 @@ class OpTask(base_task.TaskBase):
     @staticmethod
     def check_output() -> None:
         op = globals()["op"]
-        from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS, find_enabled_benchmarks
+        from tritonbench.utils.triton_op import (
+            find_enabled_benchmarks,
+            REGISTERED_BENCHMARKS,
+        )
 
         output = op.output
         output_impls = output.result[0][1].keys()
-        ci_enabled_impls = find_enabled_benchmarks(op.mode, REGISTERED_BENCHMARKS[output.op_name], op._skip)
+        ci_enabled_impls = find_enabled_benchmarks(
+            op.mode, REGISTERED_BENCHMARKS[output.op_name], op._skip
+        )
         # Make sure that all the ci_enabled impls are in the output
         assert set(output_impls) == set(
             ci_enabled_impls

--- a/tritonbench/operators/op_task.py
+++ b/tritonbench/operators/op_task.py
@@ -190,13 +190,11 @@ class OpTask(base_task.TaskBase):
     @staticmethod
     def check_output() -> None:
         op = globals()["op"]
-        from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS
+        from tritonbench.utils.triton_op import REGISTERED_BENCHMARKS, find_enabled_benchmarks
 
         output = op.output
         output_impls = output.result[0][1].keys()
-        ci_enabled_impls = [
-            x for x in REGISTERED_BENCHMARKS[output.op_name].keys() if x not in op._skip
-        ]
+        ci_enabled_impls = find_enabled_benchmarks(op.mode, REGISTERED_BENCHMARKS[output.op_name], op._skip)
         # Make sure that all the ci_enabled impls are in the output
         assert set(output_impls) == set(
             ci_enabled_impls

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -412,11 +412,11 @@ def find_enabled_benchmarks(mode, benchmark_backends, skip_benchmarks):
     """Condition: enabled, not skipped and """
     runnable = lambda m, backend: (not (m == Mode.BWD or m == Mode.FWD_BWD)) or (not backend.fwd_only)
     if skip_benchmarks:
-        benchmarks = [  bm for bm in benchmark_backends.keys() \
+        benchmarks = [ bm for bm in benchmark_backends.keys() \
             if not bm in skip_benchmarks and runnable(mode, benchmark_backends[bm])
         ]
     else:
-        benchmarks = [  bm for bm in benchmark_backends.keys() \
+        benchmarks = [ bm for bm in benchmark_backends.keys() \
             if benchmark_backends[bm].enabled and runnable(mode, benchmark_backends[bm])
         ]
     return benchmarks

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -408,15 +408,22 @@ class BenchmarkOperatorResult:
         table = tabulate.tabulate(table, headers=headers, stralign="right")
         return table
 
+
 def find_enabled_benchmarks(mode, benchmark_backends, skip_benchmarks):
-    """Condition: enabled, not skipped and """
-    runnable = lambda m, backend: (not (m == Mode.BWD or m == Mode.FWD_BWD)) or (not backend.fwd_only)
+    """Condition: enabled, not skipped and"""
+    runnable = lambda m, backend: (not (m == Mode.BWD or m == Mode.FWD_BWD)) or (
+        not backend.fwd_only
+    )
     if skip_benchmarks:
-        benchmarks = [ bm for bm in benchmark_backends.keys() \
+        benchmarks = [
+            bm
+            for bm in benchmark_backends.keys()
             if not bm in skip_benchmarks and runnable(mode, benchmark_backends[bm])
         ]
     else:
-        benchmarks = [ bm for bm in benchmark_backends.keys() \
+        benchmarks = [
+            bm
+            for bm in benchmark_backends.keys()
             if benchmark_backends[bm].enabled and runnable(mode, benchmark_backends[bm])
         ]
     return benchmarks
@@ -455,6 +462,7 @@ def register_benchmark(
         REGISTERED_BENCHMARKS[operator_name][function.__name__] = backend_config
         if backend_config.baseline:
             BASELINE_BENCHMARKS[operator_name] = function.__name__
+
         def _inner(self, *args, **kwargs):
             return function(self, *args, **kwargs)
 
@@ -653,12 +661,16 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             setattr(fwd_fn, "_name", bm_func_name)
             return fwd_fn
         elif self.mode == Mode.BWD:
-            assert not backend.fwd_only, f"Backend {bm_func_name} does not support backward pass."
+            assert (
+                not backend.fwd_only
+            ), f"Backend {bm_func_name} does not support backward pass."
             bwd_fn = self.get_bwd_fn(fwd_fn)
             setattr(bwd_fn, "_name", bm_func_name)
             return bwd_fn
         elif self.mode == Mode.FWD_BWD:
-            assert not backend.fwd_only, f"Backend {bm_func_name} does not support backward pass."
+            assert (
+                not backend.fwd_only
+            ), f"Backend {bm_func_name} does not support backward pass."
             bwd_fn = self.get_bwd_fn(fwd_fn)
             fwd_bwd_fn = lambda: (fwd_fn(), bwd_fn())
             setattr(fwd_bwd_fn, "_name", bm_func_name)
@@ -709,7 +721,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 if self._only:
                     benchmarks = self._only
                 else:
-                    benchmarks = find_enabled_benchmarks(self.mode, REGISTERED_BENCHMARKS[self.name], self._skip)
+                    benchmarks = find_enabled_benchmarks(
+                        self.mode, REGISTERED_BENCHMARKS[self.name], self._skip
+                    )
 
                 # Run the baseline first, if baseline exists
                 baseline_name = (

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -410,14 +410,14 @@ class BenchmarkOperatorResult:
 
 def find_enabled_benchmarks(mode, benchmark_backends, skip_benchmarks):
     """Condition: enabled, not skipped and """
-    run_bwd = lambda m, backend: not (m == Mode.BWD or m == Mode.FWD_BWD) or backend.fwd_only
+    runnable = lambda m, backend: (not (m == Mode.BWD or m == Mode.FWD_BWD)) or (not backend.fwd_only)
     if skip_benchmarks:
         benchmarks = [  bm for bm in benchmark_backends.keys() \
-            if not bm in skip_benchmarks and run_bwd(mode, benchmark_backends[bm])
+            if not bm in skip_benchmarks and runnable(mode, benchmark_backends[bm])
         ]
     else:
         benchmarks = [  bm for bm in benchmark_backends.keys() \
-            if benchmark_backends[bm].enabled and run_bwd(mode, benchmark_backends[bm])
+            if benchmark_backends[bm].enabled and runnable(mode, benchmark_backends[bm])
         ]
     return benchmarks
 


### PR DESCRIPTION
Some backends (e.g., flash_attention/xformers_splitk) don't have backward pass. For those backends, add `fwd_only=True` flag, and we will skip the backward pass automatically.

If user specifies `--only xformers_splitk --bwd`, we will still run the backend since it is user-specified. Otherwise we will always skip this backend.

Test plan:

```
python -m unittest test.test_gpu.main -k flash_attention
```