### PR TITLE
[FA] add persistent variant

### DIFF
--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -16,6 +16,7 @@ flash_attention:
   - triton_tutorial_flash_v2_tma
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws
+  - triton_tutorial_flash_v2_tma_ws_persistent
 fp8_attention:
   - colfax_fmha
   # triton_flash_v2 requires triton-main

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -10,6 +10,7 @@ flash_attention:
   # _ws kernels require Triton with warp specialization
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws
+  - triton_tutorial_flash_v2_tma_ws_persistent
 fp8_attention:
   # fb-only kernel
   - colfax_fmha

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -536,7 +536,7 @@ configsTmaWSPersistent = [
     )
     for BM in [128]
     for BN in [128]
-    for mult in [1] #, 2, 4, 8, 16]
+    for mult in [1]
     for sched in schedList
     for enable_tma in tmaList
     for enable_ws in [True]

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -155,7 +155,7 @@ def _attn_fwd_inner(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
+    for start_n in tl.range(lo, hi, BLOCK_N): #, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         if ENABLE_TMA:
@@ -259,7 +259,7 @@ def _attn_fwd_inner_ws(
         K_block_ptr = tl.advance(K_block_ptr, (0, lo))
         V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
     # loop over k, v and update accumulator
-    for start_n in tl.range(lo, hi, BLOCK_N, loop_schedule=LOOP_SCHEDULE):
+    for start_n in tl.range(lo, hi, BLOCK_N): #, loop_schedule=LOOP_SCHEDULE):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         # -- compute qk ----
         with tl.async_task([0]):

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -475,7 +475,7 @@ class Operator(BenchmarkOperator):
         H = self.H
 
         def get_ctx_vals():
-            for i in range(self.SEQ_LEN, 11):
+            for i in range(self.SEQ_LEN, self.SEQ_LEN+1):
                 N_CTX = 2**i
                 # BATCH = 16384 // N_CTX
                 # H = 2048 // D_HEAD

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -450,7 +450,6 @@ class Operator(BenchmarkOperator):
         BATCH, H, N_CTX, D_HEAD = q.shape
         flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
         tflops = 2 * flops_per_matmul
-        print("tflops, latency: ", tflops, metrics.latency)
         if self.causal:
             tflops *= 0.5
         if self.mode == BenchmarkMode.BWD:

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -295,6 +295,18 @@ class Operator(BenchmarkOperator):
             q, k, v, self.causal, self.sm_scale, "tma_ws"
         )
 
+    @register_benchmark(enabled=HAS_CUDA_124)
+    def triton_tutorial_flash_v2_tma_ws_persistent(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> Callable:
+        # autotune TMA/WarpSpec/CompPipe/Persistent
+        return lambda: triton_tutorial_FA2_opt(
+            q, k, v, self.causal, self.sm_scale, "tma_ws_persistent"
+        )
+
     @register_benchmark(enabled=HAS_KERNELS)
     def triton_op_flash_v2(
         self,
@@ -438,6 +450,7 @@ class Operator(BenchmarkOperator):
         BATCH, H, N_CTX, D_HEAD = q.shape
         flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
         tflops = 2 * flops_per_matmul
+        print("tflops, latency: ", tflops, metrics.latency)
         if self.causal:
             tflops *= 0.5
         if self.mode == BenchmarkMode.BWD:
@@ -459,12 +472,13 @@ class Operator(BenchmarkOperator):
     def get_input_iter(self) -> Generator:
         D_HEAD = self.D_HEAD
         BATCH = self.BATCH
+        H = self.H
 
         def get_ctx_vals():
-            for i in range(self.SEQ_LEN, 15):
+            for i in range(self.SEQ_LEN, 11):
                 N_CTX = 2**i
                 # BATCH = 16384 // N_CTX
-                H = 2048 // D_HEAD
+                # H = 2048 // D_HEAD
                 yield (BATCH, H, N_CTX, D_HEAD)
 
         ctx_vals = get_ctx_vals()

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -475,7 +475,7 @@ class Operator(BenchmarkOperator):
         H = self.H
 
         def get_ctx_vals():
-            for i in range(self.SEQ_LEN, self.SEQ_LEN+1):
+            for i in range(self.SEQ_LEN, self.SEQ_LEN + 1):
                 N_CTX = 2**i
                 # BATCH = 16384 // N_CTX
                 # H = 2048 // D_HEAD

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -474,7 +474,7 @@ class Operator(BenchmarkOperator):
         H = self.H
 
         def get_ctx_vals():
-            for i in range(self.SEQ_LEN, self.SEQ_LEN + 1):
+            for i in range(self.SEQ_LEN, 15):
                 N_CTX = 2**i
                 # BATCH = 16384 // N_CTX
                 # H = 2048 // D_HEAD


### PR DESCRIPTION
Hongtao identified the performance issue with the initial implementation and updated the assignments of tiles to each SM.

Performance with warp specialization
  (Batch, Heads, SeqLen, Dhead)    triton_tutorial_flash_v2_tma_ws_persistent-tflops    triton_tutorial_flash_v2_tma_ws-tflops    triton_tutorial_flash_v2-tflops
-------------------------------  ---------------------------------------------------  ----------------------------------------  ---------------------------------
             (8, 16, 8192, 128)                                              516.164                                   490.451                            423.905