### PR TITLE
Skip compile tk and colfax

### DIFF
--- a/.github/workflows/_linux-test-h100.yml
+++ b/.github/workflows/_linux-test-h100.yml
@@ -34,7 +34,7 @@ jobs:
           # speedup install and skip compile
           ln -s /workspace/tritonbench/.data .
           . "${SETUP_SCRIPT}"
-          python install.py --colfax --tk --hstu
+          python install.py --hstu
       - name: Test Tritonbench operators on H100 GPU
         run: |
           bash ./.ci/tritonbench/test-gpu.sh


### PR DESCRIPTION
We can reuse the build artifact from the docker.