### PR TITLE
[flash_attention] Bug fix for option `--native-sdpa`

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -212,7 +212,7 @@ class Operator(BenchmarkOperator):
     ) -> Callable:
         def sdpa_flash_attention(q, k, v):
             cxt = (
-                nullcontext
+                nullcontext()
                 if self.native_sdpa
                 else sdpa_kernel([SDPBackend.FLASH_ATTENTION])
             )


### PR DESCRIPTION
Test plan:

```
$ python run.py --op flash_attention --batch 1 --n-heads 24 --seq-len 4608 --d-head 128 --only cudnn,sdpa,flash_v3 --metrics tflops --native-sdpa

  (Batch, Heads, SeqLen, Dhead)    sdpa-tflops    cudnn_90100-tflops    flash_v3-tflops
-------------------------------  -------------  --------------------  -----------------
             (1, 24, 4608, 128)        329.483               631.338            631.827
```