### PR TITLE
Fix embedding accuracy check

### DIFF
--- a/tritonbench/operators/embedding/operator.py
+++ b/tritonbench/operators/embedding/operator.py
@@ -33,27 +33,32 @@ class Operator(BenchmarkOperator):
         for B, T, D in [(32, 512, 768), (8, 2048, 4096)]:
             for V in [2**i for i in range(10, 18)]:
                 _input = torch.randint(0, V, (B, T), device=self.device)
-                yield V, D, _input
+                tmp_embed = Embedding(V, D).to(self.device).to(self.dtype)
+                shared_weight = tmp_embed.weight.data
+                yield V, D, _input, shared_weight
 
     @register_benchmark(baseline=True)
-    def torch_embedding(self, V, D, input) -> Callable:
+    def torch_embedding(self, V, D, input, shared_weight) -> Callable:
         self.baseline_op = Embedding(V, D).to(self.device).to(self.dtype)
+        self.baseline_op.weight.data.copy_(shared_weight)
         return lambda: self.baseline_op(input)
 
     @register_benchmark()
-    def liger_embedding(self, V, D, input) -> Callable:
+    def liger_embedding(self, V, D, input, shared_weight) -> Callable:
         self.liger_op = LigerEmbedding(V, D).to(self.device).to(self.dtype)
+        self.liger_op.weight.data.copy_(shared_weight)
         return lambda: self.liger_op(input)
 
     @register_benchmark()
-    def inductor_embedding(self, V, D, input) -> Callable:
+    def inductor_embedding(self, V, D, input, shared_weight) -> Callable:
         self.baseline_op = Embedding(V, D).to(self.device).to(self.dtype)
+        self.baseline_op.weight.data.copy_(shared_weight)
         compiled = torch.compile(self.baseline_op)
         return lambda: compiled(input)
 
     @register_x_val(label="(B, T, D, V)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:
-        V, D, input_tensor = example_inputs
+        V, D, input_tensor, _ = example_inputs
         return (input_tensor.size(0), input_tensor.size(1), D, V)
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:


### PR DESCRIPTION
Force different implementations to use same weight data to make sure the accuracy check fair. 

Test Plan:

```
% python run.py --op embedding --num-inputs 1 --input-id 11 --precision fp32  --cudagraph --metrics accuracy
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.24s/it]
         (B, T, D, V)    liger_embedding-accuracy    inductor_embedding-accuracy
---------------------  --------------------------  -----------------------------
(8, 2048, 4096, 8192)                           1                              1
```