### PR TITLE
Disable donated_buffer for all ops's backward benchmarking

### DIFF
--- a/tritonbench/operators/geglu/operator.py
+++ b/tritonbench/operators/geglu/operator.py
@@ -8,6 +8,7 @@ from transformers.models.llama.modeling_llama import LlamaMLP
 
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
+    Mode,
     register_benchmark,
     register_x_val,
 )

--- a/tritonbench/operators/geglu/operator.py
+++ b/tritonbench/operators/geglu/operator.py
@@ -60,6 +60,12 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def inductor_geglu(self, input) -> Callable:
+        # TODO: remove this once we have a better way to handle backward benchmarking
+        # We need to run backward multiple times for proper benchmarking
+        # so donated buffer have to be disabled
+        if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
+            import torch._functorch.config
+
         compiled = torch.compile(self.baseline_model)
         return lambda: compiled(input)
 

--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -34,14 +34,6 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def torch_compile_layer_norm(self, *args):
-        # We need to run backward multiple times for proper benchmarking
-        # so donated buffer have to be disabled
-        if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
-            import torch._functorch.config
-
-            torch._functorch.config.donated_buffer = False
-        import torch
-
         @torch.compile
         def inner(*args):
             return F.layer_norm(*args)

--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -34,6 +34,15 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def torch_compile_layer_norm(self, *args):
+        # TODO: remove this once we have a better way to handle backward benchmarking
+        # We need to run backward multiple times for proper benchmarking
+        # so donated buffer have to be disabled
+        if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
+            import torch._functorch.config
+
+            torch._functorch.config.donated_buffer = False
+        import torch
+
         @torch.compile
         def inner(*args):
             return F.layer_norm(*args)

--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -60,6 +60,12 @@ class Operator(BenchmarkOperator):
 
     @register_benchmark()
     def inductor_swiglu(self, input) -> Callable:
+        # TODO: remove this once we have a better way to handle backward benchmarking
+        # We need to run backward multiple times for proper benchmarking
+        # so donated buffer have to be disabled
+        if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
+            import torch._functorch.config
+
         compiled = torch.compile(self.baseline_op)
         return lambda: compiled(input)
 

--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -7,6 +7,7 @@ from transformers.models.llama.modeling_llama import LlamaMLP
 
 from tritonbench.utils.triton_op import (
     BenchmarkOperator,
+    Mode,
     register_benchmark,
     register_x_val,
 )

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -623,6 +623,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         if self.mode in [Mode.FWD_BWD, Mode.BWD]:
             # TODO: remove this once we have a better way to handle backward benchmarking
             import torch._functorch.config
+
             torch._functorch.config.donated_buffer = False
         self.device = tb_args.device
         self.required_metrics = (

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -40,8 +40,6 @@ except ImportError:
     tqdm = None
 
 logger = logging.getLogger(__name__)
-# TODO: remove this once we have a better way to handle backward benchmarking
-torch._functorch.config.donated_buffer = False
 
 
 @dataclass
@@ -622,6 +620,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.tb_args.mode == "bwd"
             ), "We only accept test modes: fwd, bwd, fwd_bwd, or fwd_no_grad."
             self.mode = Mode.BWD
+        if self.mode in [Mode.FWD_BWD, Mode.BWD]:
+            # TODO: remove this once we have a better way to handle backward benchmarking
+            torch._functorch.config.donated_buffer = False
         self.device = tb_args.device
         self.required_metrics = (
             list(set(tb_args.metrics.split(",")))

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -620,11 +620,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.tb_args.mode == "bwd"
             ), "We only accept test modes: fwd, bwd, fwd_bwd, or fwd_no_grad."
             self.mode = Mode.BWD
-        if self.mode in [Mode.FWD_BWD, Mode.BWD]:
-            # TODO: remove this once we have a better way to handle backward benchmarking
-            import torch._functorch.config
-
-            torch._functorch.config.donated_buffer = False
         self.device = tb_args.device
         self.required_metrics = (
             list(set(tb_args.metrics.split(",")))

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -622,6 +622,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             self.mode = Mode.BWD
         if self.mode in [Mode.FWD_BWD, Mode.BWD]:
             # TODO: remove this once we have a better way to handle backward benchmarking
+            import torch._functorch.config
             torch._functorch.config.donated_buffer = False
         self.device = tb_args.device
         self.required_metrics = (

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -40,6 +40,8 @@ except ImportError:
     tqdm = None
 
 logger = logging.getLogger(__name__)
+# TODO: remove this once we have a better way to handle backward benchmarking
+torch._functorch.config.donated_buffer = False
 
 
 @dataclass


### PR DESCRIPTION
It is still a temporary fix for backward benchmarking. Related discussion https://github.com/pytorch-labs/tritonbench/issues/40