### PR TITLE
[flash_attention] Add pt2_sdpa

### DIFF
--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -222,12 +222,16 @@ class Operator(BenchmarkOperator):
                 else sdpa_kernel([SDPBackend.FLASH_ATTENTION])
             )
             with cxt:
-                sdpa_impl = torch.compile(
-                    sdpa,
-                    fullgraph=True,
-                    backend="inductor",
-                    mode="max-autotune",
-                ) if self.pt2_sdpa else sdpa
+                sdpa_impl = (
+                    torch.compile(
+                        sdpa,
+                        fullgraph=True,
+                        backend="inductor",
+                        mode="max-autotune",
+                    )
+                    if self.pt2_sdpa
+                    else sdpa
+                )
                 return sdpa_impl(
                     q,
                     k,


### PR DESCRIPTION
Add `--pt2-sdpa` option to test compiled sdpa.

Test plan:

```
$ python run.py --op flash_attention --batch 1 --n-heads 24 --seq-len 4608 --d-head 128 --only cudnn,sdpa,flash_v3 --metrics proton --native-sdpa --pt2-sdpa
```

Time/ns:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d8ce093c-4aaf-4aff-b36e-3ea97f5c2c3d">

Tflops:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/c7e36b6f-04ae-4dd8-b6b8-1546702e1134">

