### PR TITLE
Support flops metric in proton profiling

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -126,14 +126,14 @@ class Operator(BenchmarkOperator):
         return numel / metrics.latency * 1e3
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
         _, mat1, mat2 = example_inputs
         m, k = mat1.size()
         k, n = mat2.size()
         flops = m * k * 2 * n
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/bf16xint16_gemm/bf16xint16_gemm.py
+++ b/tritonbench/operators/bf16xint16_gemm/bf16xint16_gemm.py
@@ -142,14 +142,14 @@ class Operator(BenchmarkOperator):
         return gb / metrics.latency * 1e3
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
         a, b = example_inputs
         m, k = a.size()
         _, n = b.size()
         flops = 2 * m * n * k
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     def plot(self):
         @triton.testing.perf_report(

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -478,13 +478,6 @@ class Operator(BenchmarkOperator):
 
         return lambda: flex_attention(q, k, v, block_mask=block_mask)
 
-    @register_metric()
-    def tflops(
-        self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
-    ) -> float:
-        analytic_flops = self.flops(fn_name, example_inputs, metrics)
-        return analytic_flops / metrics.latency * 1e-9
-
     @register_metric(x_only=True)
     def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics

--- a/tritonbench/operators/fp8_attention/operator.py
+++ b/tritonbench/operators/fp8_attention/operator.py
@@ -150,10 +150,9 @@ class Operator(BenchmarkOperator):
             yield (q, k, v)
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
         H = self.embedding_dim // self.D_HEAD
         flops_per_matmul = 2.0 * self.BATCH * H * self.N_CTX * self.N_CTX * self.D_HEAD
-        tflops = 2 * flops_per_matmul
-        return tflops / metrics.latency * 1e-9
+        return 2 * flops_per_matmul

--- a/tritonbench/operators/fp8_fused_quant_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_fused_quant_gemm_rowwise/operator.py
@@ -132,14 +132,14 @@ class Operator(BenchmarkOperator):
         return lambda: _impl(x1, x2, wq, w_scale, wd)
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> List[float]:
         x1, _, wq, _, _ = example_inputs
         m, k = x1.size()
         n, k = wq.size()
         flops = m * k * 2 * n
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/fp8_gemm/fp8_gemm.py
+++ b/tritonbench/operators/fp8_gemm/fp8_gemm.py
@@ -120,14 +120,14 @@ class Operator(BenchmarkOperator):
         return gb / metrics.latency * 1e3
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
         a, b = example_inputs
         m, k = a.size()
         _, n = b.size()
         flops = 2 * m * n * k
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     def plot(self):
         @triton.testing.perf_report(

--- a/tritonbench/operators/fp8_gemm_blockwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_blockwise/operator.py
@@ -138,14 +138,14 @@ class Operator(BenchmarkOperator):
         return lambda: cutlass_fp8_block(xq, wq, x_scale, w_scale)
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> List[float]:
         xq, wq, _, _ = example_inputs
         m, k = xq.size()
         n, k = wq.size()
         flops = m * k * 2 * n
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -168,14 +168,14 @@ class Operator(BenchmarkOperator):
     #     return lambda: _cublass(xq, wq, x_scale, w_scale)
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> List[float]:
         xq, wq, _, _ = example_inputs
         m, k = xq.size()
         n, k = wq.size()
         flops = m * k * 2 * n
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     @register_x_val(label="(M, N, K)")
     def get_x_val(self, example_inputs) -> Tuple[int, int, int]:

--- a/tritonbench/operators/int4_gemm/int4_gemm.py
+++ b/tritonbench/operators/int4_gemm/int4_gemm.py
@@ -94,7 +94,7 @@ class Operator(BenchmarkOperator):
         return gb / metrics.latency * 1e3
 
     @register_metric()
-    def tflops(
+    def flops(
         self, fn_name: str, example_inputs: Any, metrics: BenchmarkOperatorMetrics
     ) -> float:
         a, b = example_inputs
@@ -102,7 +102,7 @@ class Operator(BenchmarkOperator):
         m = B * m
         _, n = b.size()
         flops = 2 * m * n * k
-        return flops / metrics.latency / 1e12 * 1e3
+        return flops
 
     def plot(self):
         @triton.testing.perf_report(

--- a/tritonbench/operators/low_mem_dropout/operator.py
+++ b/tritonbench/operators/low_mem_dropout/operator.py
@@ -26,10 +26,10 @@ class Operator(BenchmarkOperator):
         )
 
     @register_metric()
-    def tflops(self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics):
+    def flops(self, fn_name: str, example_inputs, metrics: BenchmarkOperatorMetrics):
         p, a = example_inputs
         flops = 2 * len(a)
-        return flops / metrics.latency
+        return flops
 
     @register_benchmark()
     def triton_dropout(self, p, x):


### PR DESCRIPTION
Summary:
Support tflops+proton metric on more operators.

Now we require operator to use `def flops(): ` and the framework will add `tflops` metric automatically.
The same interface will be used to support `flops` in Proton.

Differential Revision: D67062546


