### PR TITLE
Fix cudagraph mem

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1337,10 +1337,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             torch.cuda.reset_peak_memory_stats()
             torch.cuda.empty_cache()
         if use_cuda_graphs:
-            with torch.cuda.stream(torch.cuda.Stream()):
-                self.do_bench_cudagraph_mem(
-                    fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type
-                )
+            self.do_bench_cudagraph_mem(
+                fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type
+            )
         else:
             self.do_bench_mem(
                 fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1337,9 +1337,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             torch.cuda.reset_peak_memory_stats()
             torch.cuda.empty_cache()
         if use_cuda_graphs:
-            self.do_bench_cudagraph_mem(
-                fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type
-            )
+            with torch.cuda.stream(torch.cuda.Stream()):
+                self.do_bench_cudagraph_mem(
+                    fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type
+                )
         else:
             self.do_bench_mem(
                 fn, n_repeat=2, grad_to_none=grad_to_none, device_type=device_type


### PR DESCRIPTION
Fix #110 

Test Plan:
```
% python run.py --op kl_div --mode fwd  --precision fp32 --metrics latency,speedup,gpu_peak_mem,mem_footprint_compression_ratio --csv --cudagraph
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:29<00:00,  4.85s/it]
(B, T, V);torch_kl_div-gpu_peak_mem;torch_kl_div-latency;liger_kl_div-mem_footprint_compression_ratio;liger_kl_div-gpu_peak_mem;liger_kl_div-speedup;liger_kl_div-latency;inductor_kl_div-mem_footprint_compression_ratio;inductor_kl_div-gpu_peak_mem;inductor_kl_div-speedup;inductor_kl_div-latency
(8, 512, 4096);0.335545344;0.2913801074028015;2.499664352734763;0.13423616;4.345591424995377;0.06705188751220703;2.4999408737712234;0.134221312;4.5710188874722935;0.06374511122703552
(8, 512, 8192);0.671089664;0.5571430921554565;2.4998321648446384;0.268453888;4.4568456168076676;0.12500838935375214;2.4999704364909068;0.26843904;4.131225595689207;0.13486145436763763
(8, 512, 16384);1.342178304;1.0886905193328857;2.4999160795413364;0.536889344;4.558430863427795;0.238830104470253;2.499985218146775;0.536874496;4.128684738124056;0.26368942856788635
(8, 512, 32768);2.684355584;2.14784574508667;2.499958039050386;1.073760256;4.621623748214942;0.4647383391857147;2.499992609048718;1.073745408;4.12963063769356;0.5201060175895691
(8, 512, 65536);5.368710144;4.265157222747803;2.4999790193451172;2.14750208;4.651345931803366;0.9169726967811584;2.499996304518191;2.147487232;4.136367624897469;1.0311359167099
(8, 512, 131072);10.737419264;8.51184368133545;2.499989509627539;4.294985728;4.678422853171112;1.819383144378662;2.499998152257554;4.29497088;4.1419456155050405;2.05503511428833
```