### PR TITLE
Fix donated_buffer issue

### DIFF
--- a/tritonbench/operators/geglu/operator.py
+++ b/tritonbench/operators/geglu/operator.py
@@ -64,7 +64,9 @@ class Operator(BenchmarkOperator):
         # We need to run backward multiple times for proper benchmarking
         # so donated buffer have to be disabled
         if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
-            import torch._functorch.config
+            from torch._functorch import config as functorch_config
+
+            functorch_config.donated_buffer = False
 
         compiled = torch.compile(self.baseline_model)
         return lambda: compiled(input)

--- a/tritonbench/operators/layer_norm/operator.py
+++ b/tritonbench/operators/layer_norm/operator.py
@@ -38,9 +38,9 @@ class Operator(BenchmarkOperator):
         # We need to run backward multiple times for proper benchmarking
         # so donated buffer have to be disabled
         if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
-            import torch._functorch.config
+            from torch._functorch import config as functorch_config
 
-            torch._functorch.config.donated_buffer = False
+            functorch_config.donated_buffer = False
         import torch
 
         @torch.compile

--- a/tritonbench/operators/swiglu/operator.py
+++ b/tritonbench/operators/swiglu/operator.py
@@ -64,7 +64,9 @@ class Operator(BenchmarkOperator):
         # We need to run backward multiple times for proper benchmarking
         # so donated buffer have to be disabled
         if self.mode == Mode.BWD or self.mode == Mode.FWD_BWD:
-            import torch._functorch.config
+            from torch._functorch import config as functorch_config
+
+            functorch_config.donated_buffer = False
 
         compiled = torch.compile(self.baseline_op)
         return lambda: compiled(input)


### PR DESCRIPTION
The previous PR https://github.com/pytorch-labs/tritonbench/pull/104 causes the following issue.
```
% python run.py --op geglu --mode fwd  --precision fp32 --metrics latency,speedup --csv --cudagraph
  0%|                                                                                                                           | 0/4 [00:03<?, ?it/s]
Caught exception, terminating early with partial results
Traceback (most recent call last):
  File "/scratch/yhao/pta/tritonbench/tritonbench/utils/triton_op.py", line 782, in run
    y_vals: Dict[str, BenchmarkOperatorMetrics] = functools.reduce(
  File "/scratch/yhao/pta/tritonbench/tritonbench/utils/triton_op.py", line 770, in _reduce_benchmarks
    acc[bm_name] = self._do_bench(
  File "/scratch/yhao/pta/tritonbench/tritonbench/utils/triton_op.py", line 981, in _do_bench
    fn = self._get_bm_func(fn_name)
  File "/scratch/yhao/pta/tritonbench/tritonbench/utils/triton_op.py", line 667, in _get_bm_func
    fwd_fn = fwd_fn_lambda(*self.example_inputs)
  File "/scratch/yhao/pta/tritonbench/tritonbench/utils/triton_op.py", line 481, in _inner
    return function(self, *args, **kwargs)
  File "/scratch/yhao/pta/tritonbench/tritonbench/operators/geglu/operator.py", line 69, in inductor_geglu
    compiled = torch.compile(self.baseline_model)
UnboundLocalError: local variable 'torch' referenced before assignment
(B, T, H)
```
we should use `from torch._functorch import config` rather than `import torch._functorch.config`