### PR TITLE
[metrics][ncu_rep] Trace entire process on backward pass.

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1490,14 +1490,16 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         ).resolve()
         ncu_args = [
             "ncu",
-            "--nvtx",
-            "--nvtx-include",
-            f"{_RANGE_NAME}/",
             "--target-processes",
             "all",
             "--import-source",
             "yes",
         ]
+        # NCU does not recognize NVTX range on backward
+        # So we have to trace the entire process over backward
+        # See: https://github.com/pytorch-labs/tritonbench/issues/87
+        if not (self.mode == Mode.BWD or self.mode == Mode.FWD_BWD):
+            ncu_args.extend(["--nvtx", "--nvtx-include", f"{_RANGE_NAME}/"])
         ncu_args.extend(extend_ncu_args)
         if replay:
             ncu_args.extend(


### PR DESCRIPTION
NCU does not recognize NVTX range properly on the backward pass.
So we disable NVTX and its range on backward.

Workaround for https://github.com/pytorch-labs/tritonbench/issues/87

Test plan:

```
$ python run.py --op rms_norm  --mode bwd  --precision fp32 --metrics ncu_rep --cudagraph --only inductor_rms --num-inputs 1

  0%|                                                                                                                                                                                                                                     | 0/1 [00:00<?, ?it/s]==PROF== Connected to process 35243 (/home/xzhao9/miniconda3/envs/py312/bin/python3.12)
  0%|                                                                                                                                                                                                                                     | 0/1 [00:00<?, ?it/s]==WARNING== Unable to access the following 6 metrics: ctc__rx_bytes_data_user.sum, ctc__rx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__rx_bytes_data_user.sum.per_second, ctc__tx_bytes_data_user.sum, ctc__tx_bytes_data_user.sum.pct_of_peak_sustained_elapsed, ctc__tx_bytes_data_user.sum.per_second.

==PROF== Profiling "distribution_elementwise_grid..." - 0: 0%....50%....100% - 37 passes
==PROF== Profiling "triton_per_fused_add_mean_mul..." - 1: 0%....50%....100% - 37 passes
==PROF== Connected to process 35376 (/home/xzhao9/miniconda3/envs/py312/bin/python3.12)
==PROF== Profiling "distribution_elementwise_grid..." - 2: 0%....50%....100% - 37 passes
==PROF== Profiling "triton_red_fused_mul_sum_0" - 3: 0%....50%....100% - 37 passes
==PROF== Profiling "triton_per_fused_mul_sum_1" - 4: 0%....50%....100% - 37 passes
==PROF== Profiling "vectorized_elementwise_kernel" - 5: 0%....50%....100% - 37 passes
==PROF== Profiling "triton_red_fused_mul_sum_0" - 6: 0%....50%....100% - 37 passes
==PROF== Profiling "triton_per_fused_mul_sum_1" - 7: 0%....50%....100% - 37 passes
==PROF== Profiling "vectorized_elementwise_kernel" - 8: 0%....50%....100% - 37 passes
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:15<00:00, 15.18s/it]
      (M, H)    inductor_rms-_ncu_trace_in_task
------------  ---------------------------------
(2048, 1024)                            success
==PROF== Disconnected from process 35243
==PROF== Disconnected from process 35376
==PROF== Report: /tmp/tritonbench/rms_norm/ncu_traces/inductor_rms_0/ncu_output.ncu-rep
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:20<00:00, 20.28s/it]
      (M, H)                                                    inductor_rms-ncu_rep
------------  ----------------------------------------------------------------------
(2048, 1024)  /tmp/tritonbench/rms_norm/ncu_traces/inductor_rms_0/ncu_output.ncu-rep
```

Inductor backward:
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/80bab29d-277a-42e6-afc8-f4a415439f3f" />


Liger backward:
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/f7d36491-48c0-4541-b25e-60c714d2687e" />
