### PR TITLE
[op_collection] Force `--isolate` mode when running multiple ops

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ Note: make sure to `python install.py` first or otherwise make sure the benchmar
 import argparse
 import copy
 import subprocess
+import sys
 from typing import List
 
 from tritonbench.operator_loader import load_opbench_by_name_from_loader

--- a/run.py
+++ b/run.py
@@ -116,6 +116,10 @@ def run(args: List[str] = []):
     else:
         ops = list_operators_by_collection(args.op_collection)
 
+    # Force isolation in subprocess if testing more than one op.
+    if len(ops) >= 2:
+        args.isolate = True
+
     with gpu_lockdown(args.gpu_lockdown):
         for op in ops:
             args.op = op

--- a/run.py
+++ b/run.py
@@ -7,10 +7,7 @@ Note: make sure to `python install.py` first or otherwise make sure the benchmar
 
 import argparse
 import copy
-import os
 import subprocess
-import sys
-import tempfile
 from typing import List
 
 from tritonbench.operator_loader import load_opbench_by_name_from_loader
@@ -36,6 +33,7 @@ def _run_in_task(op: str) -> None:
     copy_sys_argv = copy.deepcopy(sys.argv)
     copy_sys_argv = remove_cmd_parameter(copy_sys_argv, "--op")
     copy_sys_argv = remove_cmd_parameter(copy_sys_argv, "--isolate")
+    copy_sys_argv = remove_cmd_parameter(copy_sys_argv, "--op-collection")
     add_cmd_parameter(copy_sys_argv, "--op", op)
     op_task_cmd.extend(copy_sys_argv)
     try:


### PR DESCRIPTION
Correctly run op_collection with `--isolate`.
Force using `--isolate` mode when running more than one ops.

Fixes https://github.com/pytorch-labs/tritonbench/issues/107

Test plan:

```
$ python run.py --op-collection liger --mode fwd_bwd --precision fp32 --metrics latency,speedup --dump-csv --isolate
       (B, T, V)    torch_kl_div-latency    liger_kl_div-speedup    liger_kl_div-latency    inductor_kl_div-speedup    inductor_kl_div-latency
----------------  ----------------------  ----------------------  ----------------------  -------------------------  -------------------------
  (8, 512, 4096)                0.494784                 1.40525                0.352096                    1.92266                   0.257344
  (8, 512, 8192)                0.931776                 1.49861                0.62176                     1.85099                   0.503392
 (8, 512, 16384)                1.81686                  1.54794                1.17373                     1.82287                   0.996704
 (8, 512, 32768)                3.66314                  1.55627                2.35379                     1.7796                    2.0584
 (8, 512, 65536)                7.2864                   1.57052                4.63949                     1.76966                   4.11741
(8, 512, 131072)               14.5042                   1.57413                9.21411                     1.76836                   8.20205
```