### PR TITLE
[docker] Fix the nightly docker build

### DIFF
--- a/.ci/tritonbench/install.sh
+++ b/.ci/tritonbench/install.sh
@@ -10,9 +10,5 @@ fi
 tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
 cd ${tritonbench_dir}
 
-# probe memory available
-free -h
-
 # Install Tritonbench and all its customized packages
-# Test: only install fa3
-python install.py --fa3
+python install.py --all

--- a/.ci/tritonbench/install.sh
+++ b/.ci/tritonbench/install.sh
@@ -10,5 +10,8 @@ fi
 tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
 cd ${tritonbench_dir}
 
+# probe memory available
+free -h
+
 # Install Tritonbench and all its customized packages
 python install.py --all

--- a/.ci/tritonbench/install.sh
+++ b/.ci/tritonbench/install.sh
@@ -14,4 +14,5 @@ cd ${tritonbench_dir}
 free -h
 
 # Install Tritonbench and all its customized packages
-python install.py --all
+# Test: only install fa3
+python install.py --fa3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,6 +42,8 @@ jobs:
           # branch name is github.head_ref when triggered by pull_request
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
+          # show disk space
+          df -h
           docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,6 +20,10 @@ env:
 jobs:
   build-push-docker:
     if: ${{ github.repository_owner == 'pytorch-labs' }}
+    # spec:
+    # 120G RAM
+    # 32 logical CPU cores
+    # 1T disk
     runs-on: 32-core-ubuntu
     environment: docker-s3-upload
     steps:
@@ -42,10 +46,7 @@ jobs:
           # branch name is github.head_ref when triggered by pull_request
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
-          # show disk space
-          df -h
-          # show cpu
-          lscpu
+          # limit CPU core and memory usage to keep runner daemon alive on CI machine
           taskset -c 16-31 docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
                   -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,7 +46,7 @@ jobs:
           df -h
           # show cpu
           lscpu
-          taskset -c 4-31 docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
+          taskset -c 16-31 docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
                   -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
           docker build . --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
-                  -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
+              -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')
           export DOCKER_TAG=$(awk '{match($0, /dev[0-9]+/, arr); print arr[0]}' <<< "${PYTORCH_VERSION}")

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,8 +46,8 @@ jobs:
           df -h
           # show cpu
           lscpu
-          docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
-              -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
+          taskset -c 4-31 docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
+                  -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')
           export DOCKER_TAG=$(awk '{match($0, /dev[0-9]+/, arr); print arr[0]}' <<< "${PYTORCH_VERSION}")

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,8 +46,7 @@ jobs:
           # branch name is github.head_ref when triggered by pull_request
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
-          # limit CPU core and memory usage to keep runner daemon alive on CI machine
-          taskset -c 16-31 docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
+          docker build . --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
                   -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,6 +44,8 @@ jobs:
           branch_name=${{ github.head_ref || github.ref_name }}
           # show disk space
           df -h
+          # show cpu
+          lscpu
           docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,7 +42,7 @@ jobs:
           # branch name is github.head_ref when triggered by pull_request
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
-          docker build . --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
+          docker build . --memory 100g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,7 +42,7 @@ jobs:
           # branch name is github.head_ref when triggered by pull_request
           # and it is github.ref_name when triggered by workflow_dispatch
           branch_name=${{ github.head_ref || github.ref_name }}
-          docker build . --memory 100g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
+          docker build . --memory 80g --shm-size 4g --build-arg TRITONBENCH_BRANCH="${branch_name}" --build-arg FORCE_DATE="${NIGHTLY_DATE}" \
               -f tritonbench-nightly.dockerfile -t ghcr.io/pytorch-labs/tritonbench:latest
           # Extract pytorch version from the docker
           PYTORCH_VERSION=$(docker run -e SETUP_SCRIPT="${SETUP_SCRIPT}" ghcr.io/pytorch-labs/tritonbench:latest bash -c '. "${SETUP_SCRIPT}"; python -c "import torch; print(torch.__version__)"')

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -49,6 +49,9 @@ RUN cd /workspace/tritonbench && \
 # which is from NVIDIA driver
 RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf patch
 
+# Workaround: installing Ninja from setup.py hits "Failed to decode METADATA with UTF-8" error
+RUN pip install ninja
+
 # Install Tritonbench
 RUN cd /workspace/tritonbench && \
     bash .ci/tritonbench/install.sh

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -50,7 +50,7 @@ RUN cd /workspace/tritonbench && \
 RUN sudo apt update && sudo apt-get install -y libnvidia-compute-550 patchelf patch
 
 # Workaround: installing Ninja from setup.py hits "Failed to decode METADATA with UTF-8" error
-RUN pip install ninja
+RUN . ${SETUP_SCRIPT} && pip install ninja
 
 # Install Tritonbench
 RUN cd /workspace/tritonbench && \

--- a/install.py
+++ b/install.py
@@ -65,15 +65,6 @@ def install_fa2(compile=False):
         subprocess.check_call(cmd)
 
 
-def install_fa3():
-    FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
-    env = os.environ.copy()
-    # nvcc will now spawn cicc and will cost ~1G memory
-    env["MAX_JOBS"] = "8"
-    cmd = [sys.executable, "setup.py", "install"]
-    subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)
-
-
 def install_liger():
     # Liger-kernel has a conflict dependency `triton` with pytorch,
     # so we need to install it without dependencies
@@ -130,6 +121,8 @@ if __name__ == "__main__":
         install_fa2(compile=True)
     if args.fa3 or args.all:
         logger.info("[tritonbench] installing fa3...")
+        from tools.flash_attn.install import install_fa3
+
         install_fa3()
     if args.colfax:
         logger.info("[tritonbench] installing colfax cutlass-kernels...")

--- a/install.py
+++ b/install.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     if args.fbgemm or args.all:
         logger.info("[tritonbench] installing FBGEMM...")
         install_fbgemm()
-    if args.fa2 or args.all:
+    if args.fa2:
         logger.info("[tritonbench] installing fa2 from source...")
         install_fa2(compile=True)
     if args.colfax:

--- a/install.py
+++ b/install.py
@@ -69,7 +69,7 @@ def install_fa3():
     FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
     env = os.environ.copy()
     # nvcc will now spawn cicc and will cost ~1G memory
-    env["MAX_JOBS"] = "4"
+    env["MAX_JOBS"] = "8"
     cmd = [sys.executable, "setup.py", "install"]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)
 

--- a/install.py
+++ b/install.py
@@ -114,6 +114,7 @@ if __name__ == "__main__":
     checkout_submodules(REPO_PATH)
     # install submodules
     if args.fa3 or args.all:
+        # we need to install fa3 above all other dependencies
         logger.info("[tritonbench] installing fa3...")
         from tools.flash_attn.install import install_fa3
         install_fa3()

--- a/install.py
+++ b/install.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     if args.fbgemm or args.all:
         logger.info("[tritonbench] installing FBGEMM...")
         install_fbgemm()
-    if args.fa2:
+    if args.fa2 or args.all:
         logger.info("[tritonbench] installing fa2 from source...")
         install_fa2(compile=True)
     if args.colfax:
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     if args.liger or args.all:
         logger.info("[tritonbench] installing liger-kernels...")
         install_liger()
-    if args.xformers or args.all:
+    if args.xformers:
         logger.info("[tritonbench] installing xformers...")
         from tools.xformers.install import install_xformers
 

--- a/install.py
+++ b/install.py
@@ -57,7 +57,7 @@ def install_fa2(compile=False):
     if compile:
         # compile from source (slow)
         FA2_PATH = REPO_PATH.joinpath("submodules", "flash-attention")
-        cmd = [sys.executable, "setup.py", "install"]
+        cmd = ["pip", "install", "-e", "."]
         subprocess.check_call(cmd, cwd=str(FA2_PATH.resolve()))
     else:
         # Install the pre-built binary

--- a/install.py
+++ b/install.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     if args.fa3 or args.all:
         logger.info("[tritonbench] installing fa3...")
         install_fa3()
-    if args.colfax or args.all:
+    if args.colfax:
         logger.info("[tritonbench] installing colfax cutlass-kernels...")
         from tools.cutlass_kernels.install import install_colfax_cutlass
 

--- a/install.py
+++ b/install.py
@@ -113,17 +113,16 @@ if __name__ == "__main__":
     # checkout submodules
     checkout_submodules(REPO_PATH)
     # install submodules
+    if args.fa3 or args.all:
+        logger.info("[tritonbench] installing fa3...")
+        from tools.flash_attn.install import install_fa3
+        install_fa3()
     if args.fbgemm or args.all:
         logger.info("[tritonbench] installing FBGEMM...")
         install_fbgemm()
     if args.fa2 or args.all:
         logger.info("[tritonbench] installing fa2 from source...")
         install_fa2(compile=True)
-    if args.fa3 or args.all:
-        logger.info("[tritonbench] installing fa3...")
-        from tools.flash_attn.install import install_fa3
-
-        install_fa3()
     if args.colfax:
         logger.info("[tritonbench] installing colfax cutlass-kernels...")
         from tools.cutlass_kernels.install import install_colfax_cutlass

--- a/install.py
+++ b/install.py
@@ -67,8 +67,11 @@ def install_fa2(compile=False):
 
 def install_fa3():
     FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
+    env = os.environ.copy()
+    # nvcc will now spawn cicc and will cost ~1G memory
+    env["MAX_JOBS"] = "4"
     cmd = [sys.executable, "setup.py", "install"]
-    subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()))
+    subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)
 
 
 def install_liger():

--- a/install.py
+++ b/install.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     if args.jax or args.all:
         logger.info("[tritonbench] installing jax...")
         install_jax()
-    if args.tk or args.all:
+    if args.tk:
         logger.info("[tritonbench] installing thunderkittens...")
         from tools.tk.install import install_tk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ packaging
 pynvml
 psutil
 tabulate
+ninja
 transformers==4.46.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ packaging
 pynvml
 psutil
 tabulate
-ninja
 transformers==4.46.1

--- a/tools/flash_attn/hopper.patch
+++ b/tools/flash_attn/hopper.patch
@@ -8,7 +8,7 @@ index f9f3cfd..132ce07 100644
  def append_nvcc_threads(nvcc_extra_args):
 -    return nvcc_extra_args + ["--threads", "4"]
 +    nvcc_threads = os.getenv("NVCC_THREADS") or "4"
-+    return nvcc_extra_args + ["--threads", NVCC_THREADS]
++    return nvcc_extra_args + ["--threads", nvcc_threads]
  
  
  cmdclass = {}

--- a/tools/flash_attn/hopper.patch
+++ b/tools/flash_attn/hopper.patch
@@ -1,0 +1,14 @@
+diff --git a/hopper/setup.py b/hopper/setup.py
+index f9f3cfd..132ce07 100644
+--- a/hopper/setup.py
++++ b/hopper/setup.py
+@@ -78,7 +78,8 @@ def check_if_cuda_home_none(global_option: str) -> None:
+ 
+ 
+ def append_nvcc_threads(nvcc_extra_args):
+-    return nvcc_extra_args + ["--threads", "4"]
++    nvcc_threads = os.getenv("NVCC_THREADS") or "4"
++    return nvcc_extra_args + ["--threads", NVCC_THREADS]
+ 
+ 
+ cmdclass = {}

--- a/tools/flash_attn/install.py
+++ b/tools/flash_attn/install.py
@@ -40,5 +40,5 @@ def install_fa3():
     # nvcc will spawn cicc process and will cost ~1G memory
     # env["MAX_JOBS"] = "8"
     # env["NVCC_THREADS"] = "1"
-    cmd = [sys.executable, "setup.py", "install"]
+    cmd = ["pip", "install", "-e", "."]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)

--- a/tools/flash_attn/install.py
+++ b/tools/flash_attn/install.py
@@ -39,6 +39,6 @@ def install_fa3():
     env = os.environ.copy()
     # nvcc will spawn cicc process and will cost ~1G memory
     env["MAX_JOBS"] = "8"
-    env["NVCC_THREADS"] = "2"
+    env["NVCC_THREADS"] = "1"
     cmd = [sys.executable, "setup.py", "install"]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)

--- a/tools/flash_attn/install.py
+++ b/tools/flash_attn/install.py
@@ -37,8 +37,8 @@ def install_fa3():
     patch_fa3()
     FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
     env = os.environ.copy()
-    # nvcc will spawn cicc process and will cost ~1G memory
-    # env["MAX_JOBS"] = "8"
-    # env["NVCC_THREADS"] = "1"
+    # limit nvcc memory usage on the CI machine
+    env["MAX_JOBS"] = "8"
+    env["NVCC_THREADS"] = "1"
     cmd = ["pip", "install", "-e", "."]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)

--- a/tools/flash_attn/install.py
+++ b/tools/flash_attn/install.py
@@ -38,7 +38,7 @@ def install_fa3():
     FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
     env = os.environ.copy()
     # nvcc will spawn cicc process and will cost ~1G memory
-    env["MAX_JOBS"] = "8"
-    env["NVCC_THREADS"] = "1"
+    # env["MAX_JOBS"] = "8"
+    # env["NVCC_THREADS"] = "1"
     cmd = [sys.executable, "setup.py", "install"]
     subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)

--- a/tools/flash_attn/install.py
+++ b/tools/flash_attn/install.py
@@ -1,0 +1,44 @@
+import os
+import subprocess
+import sys
+
+from pathlib import Path
+
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
+CUR_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
+
+def patch_fa3():
+    patches = ["hopper.patch"]
+    for patch_file in patches:
+        patch_file_path = os.path.join(CUR_DIR, patch_file)
+        submodule_path = str(REPO_PATH.joinpath("submodules", "flash-attention").absolute())
+        try:
+            subprocess.check_output(
+                [
+                    "patch",
+                    "-p1",
+                    "--forward",
+                    "-i",
+                    patch_file_path,
+                    "-r",
+                    "/tmp/rej",
+                ],
+                cwd=submodule_path,
+            )
+        except subprocess.SubprocessError as e:
+            output_str = str(e.output)
+            if "previously applied" in output_str:
+                return
+            else:
+                print(str(output_str))
+                sys.exit(1)
+
+def install_fa3():
+    patch_fa3()
+    FA3_PATH = REPO_PATH.joinpath("submodules", "flash-attention", "hopper")
+    env = os.environ.copy()
+    # nvcc will spawn cicc process and will cost ~1G memory
+    env["MAX_JOBS"] = "8"
+    env["NVCC_THREADS"] = "2"
+    cmd = [sys.executable, "setup.py", "install"]
+    subprocess.check_call(cmd, cwd=str(FA3_PATH.resolve()), env=env)


### PR DESCRIPTION
After the submodule update, the FA3 CUTLASS kernels now cost much more memory to build and will exhaust the CI machine.

Make the following changes:
1. Build FA3 with MAX_JOBS=4 and NVCC_THREADS=1.
2. Disable xformers build as it also requires FA3, we will try to enable its build later.
3. Also disable colfax and TK build for now - will fix that later.

Test plan: CI
