### PR TITLE
[CI] Fix the CI failure by skipping xformers

### DIFF
--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -11,6 +11,7 @@ flash_attention:
   # because of docker build time constraint
   - xformers
   - xformers_splitk
+  - colfax_cutlass
   # triton_op_flash_v2 will segfault on triton-pytorch
   - triton_op_flash_v2
   # triton_tutorial_*_ws kernels require triton-main

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -7,6 +7,10 @@
 flash_attention:
   # thunderkittens cannot handle the default input shapes
   - tk
+  # xformers fa is not included in the docker anymore
+  # because of docker build time constraint
+  - xformers
+  - xformers_splitk
   # triton_op_flash_v2 will segfault on triton-pytorch
   - triton_op_flash_v2
   # triton_tutorial_*_ws kernels require triton-main

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -11,6 +11,7 @@ flash_attention:
   # because of docker build time constraint
   - xformers
   - xformers_splitk
+  - colfax_cutlass
   # _ws kernels require Triton with warp specialization
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -7,6 +7,10 @@
 flash_attention:
   # thunderkittens cannot handle the default input shapes
   - tk
+  # xformers fa is not included in the docker anymore
+  # because of docker build time constraint
+  - xformers
+  - xformers_splitk
   # _ws kernels require Triton with warp specialization
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -100,17 +100,17 @@ except (ImportError, IOError, AttributeError, TypeError):
     HAS_XFORMERS = False
 
 # [Optional] colfax cutlass backend
-try:
-    if not hasattr(torch.version, "git_version"):
-        # colfax Flash Attention V2 for Hopper
-        torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
-    else:
-        from tritonbench.utils.loader import load_library
+# try:
+if not hasattr(torch.version, "git_version"):
+    # colfax Flash Attention V2 for Hopper
+    torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
+else:
+    from tritonbench.utils.loader import load_library
 
-        load_library("cutlass_kernels/fmha_forward_lib.so")
-    colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward
-except (ImportError, IOError, AttributeError):
-    colfax_cutlass_fmha = None
+    load_library("cutlass_kernels/fmha_forward_lib.so")
+colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward
+# except (ImportError, IOError, AttributeError):
+#     colfax_cutlass_fmha = None
 
 # [Optional] ThunderKittens backend
 try:

--- a/tritonbench/operators/flash_attention/operator.py
+++ b/tritonbench/operators/flash_attention/operator.py
@@ -100,17 +100,17 @@ except (ImportError, IOError, AttributeError, TypeError):
     HAS_XFORMERS = False
 
 # [Optional] colfax cutlass backend
-# try:
-if not hasattr(torch.version, "git_version"):
-    # colfax Flash Attention V2 for Hopper
-    torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
-else:
-    from tritonbench.utils.loader import load_library
+try:
+    if not hasattr(torch.version, "git_version"):
+        # colfax Flash Attention V2 for Hopper
+        torch.ops.load_library("//ai_codesign/gen_ai/cutlass-kernels:fmha_forward_lib")
+    else:
+        from tritonbench.utils.loader import load_library
 
-    load_library("cutlass_kernels/fmha_forward_lib.so")
-colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward
-# except (ImportError, IOError, AttributeError):
-#     colfax_cutlass_fmha = None
+        load_library("cutlass_kernels/fmha_forward_lib.so")
+    colfax_cutlass_fmha = torch.ops.cutlass.fmha_forward
+except (ImportError, IOError, AttributeError):
+    colfax_cutlass_fmha = None
 
 # [Optional] ThunderKittens backend
 try:


### PR DESCRIPTION
We have decided to skip xformers compilation in the nightly docker build because of limited docker compilation time.
Therefore we will not run or test xformers fa kernels in the CI. The tests are still available internally.