### PR TITLE
[install] Use build constraints to limit the package version

### DIFF
--- a/install.py
+++ b/install.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         setup_hip(args)
 
     if args.numpy or not has_pkg("numpy"):
-        pip_install_requirements("requirements-numpy.txt")
+        pip_install_requirements("requirements_numpy.txt")
 
     # generate build constraints before installing anything
     deps = get_pkg_versions(TRITONBENCH_DEPS)

--- a/install.py
+++ b/install.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         setup_hip(args)
 
     if args.numpy or not has_pkg("numpy"):
-        pip_install_requirements("requirements_numpy.txt")
+        pip_install_requirements("requirements_numpy.txt", add_build_constraints=False)
 
     # generate build constraints before installing anything
     deps = get_pkg_versions(TRITONBENCH_DEPS)

--- a/install.py
+++ b/install.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 from tools.cuda_utils import CUDA_VERSION_MAP, DEFAULT_CUDA_VERSION
 from tools.git_utils import checkout_submodules
-from tools.python_utils import pip_install_requirements, get_pkg_versions, generate_build_constraints
+from tools.python_utils import (
+    generate_build_constraints,
+    get_pkg_versions,
+    has_pkg,
+    pip_install_requirements,
+)
 
 from tritonbench.utils.env_utils import is_hip
 
@@ -115,7 +120,7 @@ if __name__ == "__main__":
     if args.all and is_hip():
         setup_hip(args)
 
-    if args.numpy:
+    if args.numpy or not has_pkg("numpy"):
         pip_install_requirements("requirements-numpy.txt")
 
     # generate build constraints before installing anything

--- a/requirements_numpy.txt
+++ b/requirements_numpy.txt
@@ -2,5 +2,3 @@
 # which still supports python 3.8
 numpy==1.21.2; python_version < '3.11'
 numpy==1.26.0; python_version >= '3.11'
-psutil
-pyyaml

--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -42,7 +42,7 @@ def has_pkg(pkg: str):
         cmd = [sys.executable, "-c", f"import {pkg}; print({pkg}.__version__)"]
         subprocess.check_call(cmd)
         return True
-    except subprocess.SubprocessError:
+    except subprocess.CalledProcessError:
         return False
 
 

--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -34,7 +34,7 @@ def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
 
 def generate_build_constraints(package_versions: Dict[str, str]):
     """
-    Generate package versions dict and save them to {REPO_ROOT}/build/constraints.txt
+    Generate package versions dict and save them to REPO_DIR/build/constraints.txt
     """
     output_dir = REPO_DIR.joinpath("build")
     output_dir.mkdir(exist_ok=True)

--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -2,7 +2,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 DEFAULT_PYTHON_VERSION = "3.11"
 
@@ -24,6 +24,7 @@ def create_conda_env(pyver: str, name: str):
     command = ["conda", "create", "-n", name, "-y", f"python={pyver}"]
     subprocess.check_call(command)
 
+
 def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
     versions = {}
     for module in packages:
@@ -31,6 +32,19 @@ def get_pkg_versions(packages: List[str]) -> Dict[str, str]:
         version = subprocess.check_output(cmd).decode().strip()
         versions[module] = version
     return versions
+
+
+def has_pkg(pkg: str):
+    """
+    Check if a package is installed
+    """
+    try:
+        cmd = [sys.executable, "-c", f"import {pkg}; print({pkg}.__version__)"]
+        subprocess.check_call(cmd)
+        return True
+    except subprocess.SubprocessError:
+        return False
+
 
 def generate_build_constraints(package_versions: Dict[str, str]):
     """
@@ -41,6 +55,7 @@ def generate_build_constraints(package_versions: Dict[str, str]):
     with open(output_dir.joinpath("constraints.txt"), "w") as fp:
         for k, v in package_versions.items():
             fp.write(f"{k}=={v}\n")
+
 
 def pip_install_requirements(
     requirements_txt="requirements.txt",

--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -61,23 +61,26 @@ def pip_install_requirements(
     requirements_txt="requirements.txt",
     continue_on_fail=False,
     no_build_isolation=False,
+    add_build_constraints=True,
     extra_args: Optional[List[str]] = None,
 ):
     import sys
 
     constraints_file = REPO_DIR.joinpath("build", "constraints.txt")
-    if not constraints_file.exists():
-        print(
-            "The build/constrants.txt file is not found. "
-            "Please consider rerunning the install.py script to generate it."
-            "It is recommended to install with the build/constrants.txt file "
-            "to prevent unexpected version change of numpy or torch."
-        )
-        # Test: to remove this
-        raise Exception("build/constraints.txt file is required")
-        constraints_parameters = []
+    if add_build_constraints:
+        if not constraints_file.exists():
+            print(
+                "The build/constrants.txt file is not found. "
+                "Please consider rerunning the install.py script to generate it."
+                "It is recommended to install with the build/constrants.txt file "
+                "to prevent unexpected version change of numpy or torch."
+            )
+            constraints_parameters = []
+        else:
+            constraints_parameters = ["-c", str(constraints_file.resolve())]
     else:
-        constraints_parameters = ["-c", str(constraints_file.resolve())]
+        constraints_parameters = []
+
     if no_build_isolation:
         constraints_parameters.append("--no-build-isolation")
     if extra_args and isinstance(extra_args, list):

--- a/tools/python_utils.py
+++ b/tools/python_utils.py
@@ -39,7 +39,7 @@ def has_pkg(pkg: str):
     Check if a package is installed
     """
     try:
-        cmd = [sys.executable, "-c", f"import {pkg}; print({pkg}.__version__)"]
+        cmd = [sys.executable, "-c", f"import {pkg}; {pkg}.__version__"]
         subprocess.check_call(cmd)
         return True
     except subprocess.CalledProcessError:
@@ -73,6 +73,8 @@ def pip_install_requirements(
             "It is recommended to install with the build/constrants.txt file "
             "to prevent unexpected version change of numpy or torch."
         )
+        # Test: to remove this
+        raise Exception("build/constraints.txt file is required")
         constraints_parameters = []
     else:
         constraints_parameters = ["-c", str(constraints_file.resolve())]


### PR DESCRIPTION
Promote numpy version file to `requirements_numpy.txt` and used by install.py to install the suggested version.

Optionally user can install it with `python install.py --numpy`.

Use build constraints to make sure numpy and torch version are consistent throughout the install.