### PR TITLE
[nightly] Run the workflow from non-pull-request

### DIFF
--- a/.ci/tritonbench/run-benchmark.sh
+++ b/.ci/tritonbench/run-benchmark.sh
@@ -15,4 +15,7 @@ fi
 
 BENCHMARK_NAME=$1
 
+tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
+cd ${tritonbench_dir}
+
 python "benchmarks/${BENCHMARK_NAME}/run.py" --ci

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Benchmarking
         run: |
           if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
-            cd /workspace/tritonbench
+            export repo_prefix=/workspace/tritonbench
+          else
+            export repo_prefix=$PWD
           fi
-          bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
-          cp -r ./.benchmarks/${{ inputs.benchmark_name }} benchmark-output
+          bash "${repo_prefix}"/.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
+          cp -r "${repo_prefix}"/.benchmarks/${{ inputs.benchmark_name }} benchmark-output
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -54,9 +56,11 @@ jobs:
           path: benchmark-output/
       - name: Upload result to Scribe
         run: |
-          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
-            cd /workspace/tritonbench
-          fi
           . "${SETUP_SCRIPT}"
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            export repo_prefix=/workspace/tritonbench
+          else
+            export repo_prefix=$PWD
+          fi
           latest_result_json=$(find ./benchmark-output/ -name "result.json"  | sort -r | head -n 1)
-          python ./.ci/upload/scribe.py --json ${latest_result_json}
+          python "${repo_prefix}"/.ci/upload/scribe.py --json ${latest_result_json}

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -30,8 +30,7 @@ jobs:
       JOB_NAME: tritonbench-h100-${{ inputs.conda_env }}-${{ inputs.benchmark_name }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
     steps:
-      - name: Checkout Tritonbench (if on pull_request)
-        if: github.event_name == 'pull_request'
+      - name: Checkout Tritonbench
         uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -42,13 +41,8 @@ jobs:
           nvidia-smi
       - name: Benchmarking
         run: |
-          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
-            export repo_prefix=/workspace/tritonbench
-          else
-            export repo_prefix=$PWD
-          fi
-          bash "${repo_prefix}"/.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
-          cp -r "${repo_prefix}"/.benchmarks/${{ inputs.benchmark_name }} benchmark-output
+          bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -57,10 +51,5 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
-            export repo_prefix=/workspace/tritonbench
-          else
-            export repo_prefix=$PWD
-          fi
           latest_result_json=$(find ./benchmark-output/ -name "result.json"  | sort -r | head -n 1)
-          python "${repo_prefix}"/.ci/upload/scribe.py --json ${latest_result_json}
+          python .ci/upload/scribe.py --json ${latest_result_json}


### PR DESCRIPTION
https://github.com/pytorch-labs/tritonbench/actions/runs/12915411711 works but it fails to upload the artifacts to GH Artifact.

We need to fix the artifact path when the workflow is not running in a PR.

Test Plan:

https://github.com/pytorch-labs/tritonbench/actions/runs/12919821483