### PR TITLE
Update FBGEMM version

### DIFF
--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -53,14 +53,15 @@ except (ImportError, AssertionError):
 
 try:
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401
-    cutlass_or_ck_fp8_row = torch.ops.fbgemm.f8f8bf16_rowwise
 
+    cutlass_or_ck_fp8_row = torch.ops.fbgemm.f8f8bf16_rowwise
     HAS_CUTLASS_OR_CK = True
 except (ImportError, ModuleNotFoundError, AttributeError):
     HAS_CUTLASS_OR_CK = False
 
 try:
     import fbgemm_gpu.experimental.gen_ai  # noqa: F401
+
     cublas_fp8_row = torch.ops.fbgemm.f8f8bf16_cublas
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import scale_fp8_row
 

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -56,7 +56,7 @@ try:
     cutlass_or_ck_fp8_row = torch.ops.fbgemm.f8f8bf16_rowwise
 
     HAS_CUTLASS_OR_CK = True
-except (ImportError, AttributeError):
+except (ImportError, ModuleNotFoundError, AttributeError):
     HAS_CUTLASS_OR_CK = False
 
 try:
@@ -65,7 +65,7 @@ try:
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import scale_fp8_row
 
     HAS_CUBLAS = True
-except (ImportError, IOError, AttributeError):
+except (ImportError, IOError, AttributeError, ModuleNotFoundError):
     HAS_CUBLAS = False
 
 

--- a/tritonbench/operators/fp8_gemm_rowwise/operator.py
+++ b/tritonbench/operators/fp8_gemm_rowwise/operator.py
@@ -2,8 +2,6 @@ import argparse
 import os
 from typing import Any, Callable, Generator, List, Optional, Tuple
 
-import fbgemm_gpu.experimental.gen_ai  # noqa: F401
-
 import torch
 import triton
 
@@ -54,12 +52,15 @@ except (ImportError, AssertionError):
     HAS_TRITON = False
 
 try:
+    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
     cutlass_or_ck_fp8_row = torch.ops.fbgemm.f8f8bf16_rowwise
+
     HAS_CUTLASS_OR_CK = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_CUTLASS_OR_CK = False
 
 try:
+    import fbgemm_gpu.experimental.gen_ai  # noqa: F401
     cublas_fp8_row = torch.ops.fbgemm.f8f8bf16_cublas
     from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import scale_fp8_row
 


### PR DESCRIPTION
Update FBGEMM version to include https://github.com/pytorch/FBGEMM/commit/559945b356c3a7e26a4356f7b11dba74f9dbd2ba

This upstream commit fixes FBGEMM RoCM build to include Triton kernels.

Fixes https://github.com/pytorch-labs/tritonbench/issues/129

Test plan:

```
$ python run.py --op fp8_gemm_rowwise --m 8192 --n 16384  --k 16384 --no_use_tma --no_use_persistent 
```

