### PR TITLE
[tritonbench] Change default precision for addmm to fp16

### DIFF
--- a/tritonbench/operators/addmm/operator.py
+++ b/tritonbench/operators/addmm/operator.py
@@ -76,7 +76,7 @@ LARGE_K_SHAPES = list(itertools.product([13], [2**i for i in range(6, 26)], [2])
 
 class Operator(BenchmarkOperator):
     DEFAULT_METRICS = ["tflops", "best_config"]
-    DEFAULT_PRECISION = "bf16"
+    DEFAULT_PRECISION = "fp16"
 
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None


### PR DESCRIPTION
streamk was recently added to the addmm benchmarks---but atomic_add does not support bf16 in upstream Triton, so we should change the default to fp16.