### PR TITLE
Add nvidia states to the json

### DIFF
--- a/benchmarks/nightly/run.py
+++ b/benchmarks/nightly/run.py
@@ -66,9 +66,9 @@ OPERATOR_BENCHMARKS = {
 
 def reduce(run_timestamp, output_dir, output_files, args):
     """aggregate all op benchmark csvs into json file"""
+    from tritonbench.utils.gpu_utils import get_nvidia_gpu_states, has_nvidia_smi
     from tritonbench.utils.path_utils import REPO_PATH
     from tritonbench.utils.run_utils import get_github_env, get_run_env
-    from tritonbench.utils.gpu_utils import get_nvidia_gpu_states, has_nvidia_smi
 
     repo_locs = {
         "tritonbench": REPO_PATH,
@@ -82,9 +82,11 @@ def reduce(run_timestamp, output_dir, output_files, args):
         "metrics": {},
     }
     if has_nvidia_smi():
-        aggregated_obj.update({
-            "nvidia_gpu_states": get_nvidia_gpu_states(),
-        })
+        aggregated_obj.update(
+            {
+                "nvidia_gpu_states": get_nvidia_gpu_states(),
+            }
+        )
 
     # Collecting GitHub environment variables when running in CI environment
     if args.ci:

--- a/benchmarks/nightly/run.py
+++ b/benchmarks/nightly/run.py
@@ -68,6 +68,7 @@ def reduce(run_timestamp, output_dir, output_files, args):
     """aggregate all op benchmark csvs into json file"""
     from tritonbench.utils.path_utils import REPO_PATH
     from tritonbench.utils.run_utils import get_github_env, get_run_env
+    from tritonbench.utils.gpu_utils import get_nvidia_gpu_states, has_nvidia_smi
 
     repo_locs = {
         "tritonbench": REPO_PATH,
@@ -80,6 +81,11 @@ def reduce(run_timestamp, output_dir, output_files, args):
         "env": get_run_env(run_timestamp, repo_locs),
         "metrics": {},
     }
+    if has_nvidia_smi():
+        aggregated_obj.update({
+            "nvidia_gpu_states": get_nvidia_gpu_states(),
+        })
+
     # Collecting GitHub environment variables when running in CI environment
     if args.ci:
         aggregated_obj["github"] = get_github_env()

--- a/tritonbench/utils/gpu_utils.py
+++ b/tritonbench/utils/gpu_utils.py
@@ -35,23 +35,23 @@ AMD_MI300X = {
 }
 
 
-HW_ROOFLINE_SPECS: Dict[bool, Dict[str, Dict[str, float]]] = (
-    {  # true is compute bound false would be memory bound
-        True: {
-            "NVIDIA A100-SXM4-40GB": NV_A100,
-            "NVIDIA A100-PG509-200": NV_A100,
-            "NVIDIA H100": NV_H100,
-            "AMD MI300X": AMD_MI300X,
-        },
-        False: {
-            # https://www.nvidia.com/en-gb/data-center/h100
-            # values in gbps
-            "NVIDIA H100": 2000,
-            # https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-platform-data-sheet.pdf
-            "AMD MI300X": 5300,
-        },
-    }
-)
+HW_ROOFLINE_SPECS: Dict[
+    bool, Dict[str, Dict[str, float]]
+] = {  # true is compute bound false would be memory bound
+    True: {
+        "NVIDIA A100-SXM4-40GB": NV_A100,
+        "NVIDIA A100-PG509-200": NV_A100,
+        "NVIDIA H100": NV_H100,
+        "AMD MI300X": AMD_MI300X,
+    },
+    False: {
+        # https://www.nvidia.com/en-gb/data-center/h100
+        # values in gbps
+        "NVIDIA H100": 2000,
+        # https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/data-sheets/amd-instinct-mi300x-platform-data-sheet.pdf
+        "AMD MI300X": 5300,
+    },
+}
 
 CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES", "0")
 


### PR DESCRIPTION
Fixes https://github.com/pytorch-labs/tritonbench/issues/144

Test plan:

```
{
    "name": "nightly",
    "env": {
        "benchmark_date": "20250127094509",
        "cuda_version": "12.4",
        "device": "NVIDIA H100",
        "conda_env": "unknown",
        "pytorch_commit": "ab2a8287ca8762fba514e29b8800e893ffbe8bb4",
        "triton_commit": "unknown",
        "tritonbench_commit": "4a39898dcae6bd4c521f539d6022583fb5cc67a2",
        "triton_branch": "unknown",
        "triton_commit_time": "unknown",
        "pytorch_branch": "unknown",
        "pytorch_commit_time": "unknown",
        "tritonbench_branch": "xz9/add-nv-state",
        "tritonbench_commit_time": "20250127115104"
    },
    "metrics": {
        "tritonbench_launch_latency_fwd[x_0-nop_python_function]_latency": 0.0029120000544935465,
        "tritonbench_launch_latency_fwd[x_0-nop_python_function]_walltime": 2.4475443555024695e-05,
        "tritonbench_launch_latency_fwd[x_0-nop_triton_kernel]_latency": 0.00470399996265769,
        "tritonbench_launch_latency_fwd[x_0-nop_triton_kernel]_walltime": 0.009760101436662188,
        "tritonbench_launch_latency_fwd[x_0-nop_triton_compiled_kernel_run]_latency": 0.004608000162988901,
        "tritonbench_launch_latency_fwd[x_0-nop_triton_compiled_kernel_run]_walltime": 0.002765528904799707,
        "tritonbench_launch_latency_fwd[x_19-nop_python_function]_latency": 0.0029120000544935465,
        "tritonbench_launch_latency_fwd[x_19-nop_python_function]_walltime": 2.45875940004749e-05,
        "tritonbench_launch_latency_fwd[x_19-nop_triton_kernel]_latency": 0.004736000206321478,
        "tritonbench_launch_latency_fwd[x_19-nop_triton_kernel]_walltime": 0.018367795720601217,
        "tritonbench_launch_latency_fwd[x_19-nop_triton_compiled_kernel_run]_latency": 0.00470399996265769,
        "tritonbench_launch_latency_fwd[x_19-nop_triton_compiled_kernel_run]_walltime": 0.004247018210819842,
        "tritonbench_launch_latency_fwd[nop_python_function]-latency-avg": 0.0029120000544935465,
        "tritonbench_launch_latency_fwd[nop_python_function]-walltime-avg": 2.4531518777749796e-05,
        "tritonbench_launch_latency_fwd[nop_triton_kernel]-latency-avg": 0.004720000084489584,
        "tritonbench_launch_latency_fwd[nop_triton_kernel]-walltime-avg": 0.014063948578631701,
        "tritonbench_launch_latency_fwd[nop_triton_compiled_kernel_run]-latency-avg": 0.004656000062823296,
        "tritonbench_launch_latency_fwd[nop_triton_compiled_kernel_run]-walltime-avg": 0.0035062735578097744,
        "tritonbench_softmax_fwd[x_[4096, 256]-naive_softmax]_gbps": 436.19640378820435,
        "tritonbench_softmax_fwd[x_[4096, 256]-naive_softmax]_latency": 0.019231263548135757,
        "tritonbench_softmax_fwd[x_[4096, 256]-triton_softmax]_gbps": 1795.3167436622641,
        "tritonbench_softmax_fwd[x_[4096, 256]-triton_softmax]_latency": 0.00467249471694231,
        "tritonbench_softmax_fwd[x_[4096, 384]-naive_softmax]_gbps": 499.98426797274215,
        "tritonbench_softmax_fwd[x_[4096, 384]-naive_softmax]_latency": 0.025166615843772888,
        "tritonbench_softmax_fwd[x_[4096, 384]-triton_softmax]_gbps": 2706.498835355139,
        "tritonbench_softmax_fwd[x_[4096, 384]-triton_softmax]_latency": 0.004649147391319275,
        "tritonbench_softmax_fwd[x_[4096, 512]-naive_softmax]_gbps": 560.9558255808503,
        "tritonbench_softmax_fwd[x_[4096, 512]-naive_softmax]_latency": 0.02990826591849327,
        "tritonbench_softmax_fwd[x_[4096, 512]-triton_softmax]_gbps": 3575.7025744790685,
        "tritonbench_softmax_fwd[x_[4096, 512]-triton_softmax]_latency": 0.004692005459219217,
        "tritonbench_softmax_fwd[x_[4096, 640]-naive_softmax]_gbps": 591.845819416426,
        "tritonbench_softmax_fwd[x_[4096, 640]-naive_softmax]_latency": 0.035434093326330185,
        "tritonbench_softmax_fwd[x_[4096, 640]-triton_softmax]_gbps": 4169.153471231113,
        "tritonbench_softmax_fwd[x_[4096, 640]-triton_softmax]_latency": 0.0050301626324653625,
        "tritonbench_softmax_fwd[x_[4096, 768]-naive_softmax]_gbps": 595.9119278420006,
        "tritonbench_softmax_fwd[x_[4096, 768]-naive_softmax]_latency": 0.04223077744245529,
        "tritonbench_softmax_fwd[x_[4096, 768]-triton_softmax]_gbps": 4695.484107016819,
        "tritonbench_softmax_fwd[x_[4096, 768]-triton_softmax]_latency": 0.005359580274671316,
        "tritonbench_softmax_fwd[x_[4096, 896]-naive_softmax]_gbps": 613.2756130615483,
        "tritonbench_softmax_fwd[x_[4096, 896]-naive_softmax]_latency": 0.04787427932024002,
        "tritonbench_softmax_fwd[x_[4096, 896]-triton_softmax]_gbps": 5197.463619275598,
        "tritonbench_softmax_fwd[x_[4096, 896]-triton_softmax]_latency": 0.005648933816701174,
        "tritonbench_softmax_fwd[naive_softmax]-gbps-avg": 549.6949762769619,
        "tritonbench_softmax_fwd[naive_softmax]-latency-avg": 0.0333075492332379,
        "tritonbench_softmax_fwd[triton_softmax]-gbps-avg": 3689.936558503334,
        "tritonbench_softmax_fwd[triton_softmax]-latency-avg": 0.005008720715219776,
        "tritonbench_gemm_fwd[x_(256, 256, 256)-aten_matmul]_latency": 0.003235557349398732,
        "tritonbench_gemm_fwd[x_(256, 256, 256)-aten_matmul]_tflops": 10.37052611854816,
        "tritonbench_gemm_fwd[x_(256, 256, 256)-triton_tutorial_matmul]_latency": 0.0032695000991225243,
        "tritonbench_gemm_fwd[x_(256, 256, 256)-triton_tutorial_matmul]_tflops": 10.26286312363331,
        "tritonbench_gemm_fwd[x_(384, 384, 384)-aten_matmul]_latency": 0.004918833263218403,
        "tritonbench_gemm_fwd[x_(384, 384, 384)-aten_matmul]_tflops": 23.02298165843962,
        "tritonbench_gemm_fwd[x_(384, 384, 384)-triton_tutorial_matmul]_latency": 0.0038722960744053125,
        "tritonbench_gemm_fwd[x_(384, 384, 384)-triton_tutorial_matmul]_tflops": 29.24523482295753,
        "tritonbench_gemm_fwd[x_(512, 512, 512)-aten_matmul]_latency": 0.00490636145696044,
        "tritonbench_gemm_fwd[x_(512, 512, 512)-aten_matmul]_tflops": 54.71171627992928,
        "tritonbench_gemm_fwd[x_(512, 512, 512)-triton_tutorial_matmul]_latency": 0.004502078518271446,
        "tritonbench_gemm_fwd[x_(512, 512, 512)-triton_tutorial_matmul]_tflops": 59.62478328855638,
        "tritonbench_gemm_fwd[x_(640, 640, 640)-aten_matmul]_latency": 0.007917425595223904,
        "tritonbench_gemm_fwd[x_(640, 640, 640)-aten_matmul]_tflops": 66.2195045213018,
        "tritonbench_gemm_fwd[x_(640, 640, 640)-triton_tutorial_matmul]_latency": 0.005927360616624355,
        "tritonbench_gemm_fwd[x_(640, 640, 640)-triton_tutorial_matmul]_tflops": 88.45218536721715,
        "tritonbench_gemm_fwd[aten_matmul]-latency-avg": 0.00524454441620037,
        "tritonbench_gemm_fwd[aten_matmul]-tflops-avg": 38.58118214455472,
        "tritonbench_gemm_fwd[triton_tutorial_matmul]-latency-avg": 0.00439280882710591,
        "tritonbench_gemm_fwd[triton_tutorial_matmul]-tflops-avg": 46.896266650591095
    },
    "nvidia_gpu_states": {
        "power.draw.average": "122.06",
        "power.draw.instant": "122.07",
        "temperature.gpu": "42",
        "temperature.memory": "57",
        "clocks.current.sm": "1980",
        "clocks.current.memory": "1593",
        "hw_thermal_slowdown": "Not Active",
        "sw_thermal_slowdown": "Not Active"
    }
}
```