### PR TITLE
[compile_trace] Add compile time Kineto trace

### DIFF
--- a/tritonbench/components/compile_time/__init__.py
+++ b/tritonbench/components/compile_time/__init__.py
@@ -1,1 +1,5 @@
-from .trace import do_compile_time_in_task, fbcode_do_compile_time_in_task  # noqa F401
+from .trace import (  # noqa F401
+    do_compile_kineto_trace_in_task,
+    do_compile_time_in_task,
+    fbcode_do_compile_time_in_task,
+)

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1656,7 +1656,6 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         op_task.run()
         if kineto_trace:
             kineto_trace_loc = op_task.get_attribute("_compile_time_kineto_trace")
-            print(f"kineto_trace_loc: {kineto_trace_loc}")
             del op_task
             return kineto_trace_loc
         if op_task.get_attribute("triton_hook_latency") is not None:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -199,6 +199,8 @@ class BenchmarkOperatorMetrics:
     compile_time: Optional[float] = None
     # stage breakdown of compile times
     compile_time_by_stage: Optional[Dict[str, float]] = None
+    # compile time with kineto trace
+    compile_trace: Optional[str] = None
     # ncu trace file
     ncu_trace: Optional[str] = None
     # ncu replay file
@@ -1145,6 +1147,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 metrics.compile_time = compile_time
                 if compile_time_by_stage:
                     metrics.compile_time_by_stage = compile_time_by_stage
+            if "compile_trace" in self.required_metrics:
+                metrics.compile_trace = self.compile_time(
+                    input_id, fn_name, metrics, kineto_trace=True
+                )
             if "ncu_trace" in self.required_metrics:
                 metrics.ncu_trace = self.ncu_trace(input_id, fn_name)
             # Collect NCU metrics if any required metrics match the ncu analyzer
@@ -1236,6 +1242,29 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 metrics.all_configs = self.all_configs(fn)
             if "kernel_source_hash" in self.required_metrics:
                 metrics.kernel_source_hash = self.kernel_hash(fn)
+            if "_compile_time_kineto_trace_in_task" in self.required_metrics:
+                assert (
+                    self.required_metrics == ["_compile_time_kineto_trace_in_task"]
+                    and len(self._only) == 1
+                    and (self._input_id is not None)
+                ), (
+                    "_compile_time_kineto_trace_in_task must be measured by itself. "
+                    f"required_metrics: {self.required_metrics}, _only: {self._only}, _input_id: {self._input_id}"
+                )
+                from tritonbench.components.compile_time import (
+                    do_compile_kineto_trace_in_task,
+                )
+
+                kineto_trace_output_dir = self.get_temp_path("kineto_trace")
+                kineto_trace_output_dir.mkdir(parents=True, exist_ok=True)
+                metrics.extra_metrics["_compile_time_kineto_trace"] = (
+                    do_compile_kineto_trace_in_task(
+                        fn, output_dir=str(kineto_trace_output_dir)
+                    )
+                )
+                self._compile_time_kineto_trace = metrics.extra_metrics[
+                    "_compile_time_kineto_trace"
+                ]
             if "_compile_time_in_task" in self.required_metrics:
                 assert (
                     self.required_metrics == ["_compile_time_in_task"]
@@ -1591,8 +1620,12 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         )
 
     def compile_time(
-        self, input_id: int, fn_name: str, metrics: BenchmarkOperatorMetrics
-    ) -> float:
+        self,
+        input_id: int,
+        fn_name: str,
+        metrics: BenchmarkOperatorMetrics,
+        kineto_trace: bool = False,
+    ) -> Union[float, str]:
         # We need to spawn a subprocess when user wants to measure the compile time
         # of multiple sample inputs and backends.
         from tritonbench.operators.op_task import OpTask
@@ -1611,12 +1644,21 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 "--input-id",
                 str(input_id),
                 "--metrics",
-                "_compile_time_in_task",
+                (
+                    "_compile_time_in_task"
+                    if not kineto_trace
+                    else "_compile_time_kineto_trace_in_task"
+                ),
             ]
         )
         op_task = OpTask(name=self.name)
         op_task.make_operator_instance(args=op_task_args)
         op_task.run()
+        if kineto_trace:
+            kineto_trace_loc = op_task.get_attribute("_compile_time_kineto_trace")
+            print(f"kineto_trace_loc: {kineto_trace_loc}")
+            del op_task
+            return kineto_trace_loc
         if op_task.get_attribute("triton_hook_latency") is not None:
             compiled_time = op_task.get_attribute("triton_hook_latency")
             compile_time_by_stage = op_task.get_attribute("compile_time_by_stage")


### PR DESCRIPTION
Generates Kineto trace focusing on compile time so that we can peek into compile time analysis.

Fixes https://github.com/pytorch-labs/tritonbench/issues/117

Test plan:

```
$ python run.py --op softmax --num-inputs 1 --input-id 0 --metrics compile_trace --only triton_softmax
```

<img width="632" alt="image" src="https://github.com/user-attachments/assets/bfacd02d-2033-435a-9836-08b6d8bc03ae" />

Internal link only: https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftritonbench%2Fcompile_time.json&bucket=tc_bench_ci

With autotuning:

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/47982b37-5597-41c2-95b1-096315e5f5ea" />
