### PR TITLE
Skip cold start time for compilation trace

### DIFF
--- a/tritonbench/kernels/nop.py
+++ b/tritonbench/kernels/nop.py
@@ -1,0 +1,6 @@
+import triton
+
+
+@triton.jit
+def nop_kernel():
+    pass

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -175,6 +175,11 @@ def get_parser(args=None):
         action="store_true",
         help="when true randomly shuffles the inputs before running benchmarks where possible.",
     )
+    parser.add_argument(
+        "--compile-cold-start",
+        action="store_true",
+        help="Include cold start time in compile_time and compile_trace.",
+    )
 
     if IS_FBCODE:
         parser.add_argument("--log-scuba", action="store_true", help="Log to scuba.")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1259,7 +1259,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 kineto_trace_output_dir.mkdir(parents=True, exist_ok=True)
                 metrics.extra_metrics["_compile_time_kineto_trace_in_task"] = (
                     do_compile_kineto_trace_in_task(
-                        fn, output_dir=str(kineto_trace_output_dir)
+                        fn,
+                        output_dir=str(kineto_trace_output_dir),
+                        cold_start=self.tb_args.compile_cold_start,
                     )
                 )
                 self._compile_time_kineto_trace_in_task = metrics.extra_metrics[
@@ -1294,7 +1296,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                         )  # converting from ms to s
                 if "compile_times" not in metrics.extra_metrics:
                     metrics.extra_metrics["_compile_time_in_task"] = (
-                        do_compile_time_in_task(fn)
+                        do_compile_time_in_task(
+                            fn, cold_start=self.tb_args.compile_cold_start
+                        )
                     )
                     self._latency_with_compile_in_task = metrics.extra_metrics[
                         "_compile_time_in_task"
@@ -1651,6 +1655,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 ),
             ]
         )
+        if self.tb_args.compile_cold_start:
+            op_task_args.append("--compile-cold-start")
         op_task = OpTask(name=self.name, save_output_dir=Path("/tmp/tritonbench"))
         op_task.make_operator_instance(args=op_task_args)
         op_task.run()


### PR DESCRIPTION
Summary:
We introduce option `--compile-cold-start` to let user decide whether to include cold start time in compile_time or compile_trace.

By default, the compiler cold start overhead will be ignored. This will remove misleading part like triton_key in OSS and build_remote in Internal overhead and focus on the essential compilation part.

If user still wants to view the cold start overhead, use `--compile-cold-start` option.

Differential Revision: D69183649


