### PR TITLE
[rope] Fix running with cudagraph

### DIFF
--- a/tritonbench/operators/rope/operator.py
+++ b/tritonbench/operators/rope/operator.py
@@ -45,18 +45,26 @@ class Operator(BenchmarkOperator):
     def prepare_input(self, hidden_size, seq_length):
         head_dim = hidden_size // self.num_q_heads
         rotary_emb = LlamaRotaryEmbedding(head_dim, device=self.device)
-        q = torch.randn(
-            (1, seq_length, self.num_q_heads, head_dim),
-            device=self.device,
-            requires_grad=True,
-            dtype=self.dtype,
-        ).transpose(1, 2)
-        k = torch.randn(
-            (1, seq_length, self.num_kv_heads, head_dim),
-            device=self.device,
-            requires_grad=True,
-            dtype=self.dtype,
-        ).transpose(1, 2)
+        q = (
+            torch.randn(
+                (1, seq_length, self.num_q_heads, head_dim),
+                device=self.device,
+                requires_grad=True,
+                dtype=self.dtype,
+            )
+            .transpose(1, 2)
+            .contiguous()
+        )
+        k = (
+            torch.randn(
+                (1, seq_length, self.num_kv_heads, head_dim),
+                device=self.device,
+                requires_grad=True,
+                dtype=self.dtype,
+            )
+            .transpose(1, 2)
+            .contiguous()
+        )
         dq, dk = (
             torch.randn_like(q, device=self.device, dtype=self.dtype),
             torch.randn_like(k, device=self.device),


### PR DESCRIPTION
Tensor view does not support in-place detaching with `.detach_()`, use `.contiguous()` call to convert tensor views to tensor.

Fixes https://github.com/pytorch-labs/tritonbench/issues/155

Test plan:

```
$ python run.py --op rope  --cudagraph
       (H, T)    apply_rotary_pos_emb-latency    liger_rotary_pos_emb-latency    inductor_rotary_pos_emb_full_op-latency
-------------  ------------------------------  ------------------------------  -----------------------------------------
 (8192, 1024)               0.209794 (±0.08%)               0.079294 (±0.09%)                          0.044696 (±0.17%)
 (8192, 2048)               0.425296 (±0.07%)               0.167398 (±0.07%)                          0.083712 (±0.10%)
 (8192, 4096)               0.869108 (±0.07%)               0.333221 (±0.04%)                          0.175674 (±0.27%)
 (8192, 8192)               1.734228 (±0.05%)               0.655273 (±0.05%)                          0.442072 (±1.22%)
(8192, 16384)              4.405540 (±13.46%)               1.325537 (±8.78%)                          1.177186 (±0.31%)
  (512, 2048)               0.033462 (±0.33%)               0.010369 (±0.14%)                          0.006766 (±0.16%)
 (2048, 2048)               0.098888 (±0.23%)               0.027084 (±0.25%)                          0.019540 (±1.82%)
 (8192, 2048)               0.424953 (±0.06%)               0.167613 (±0.05%)                          0.088726 (±0.66%)
```