### PR TITLE
[ci] Enable more tests

### DIFF
--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -6,14 +6,6 @@ on:
         required: True
         description: |
           Tritonbench Scribe Graph Access Token
-      AWS_ACCESS_KEY_ID:
-        required: True
-        description: |
-          AWS S3 bucket access key
-      AWS_SECRET_ACCESS_KEY:
-        required: True
-        description: |
-          AWS S3 bucket secret access key
     inputs:
       benchmark_name:
         required: True

--- a/.github/workflows/compile-time.yaml
+++ b/.github/workflows/compile-time.yaml
@@ -18,8 +18,6 @@ jobs:
       benchmark_name: "compile_time"
     secrets:
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 
 

--- a/test/test_gpu/main.py
+++ b/test/test_gpu/main.py
@@ -1,8 +1,7 @@
-import argparse
 import logging
 import unittest
 
-from typing import List, Dict
+from typing import Dict, List
 
 import yaml
 

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -31,6 +31,11 @@ jagged_mean:
 jagged_softmax:
 jagged_sum:
 ragged_attention:
+  # ../../../lib/Tools/LinearLayout.cpp:565: LinearLayout
+  # mlir::triton::LinearLayout::reshapeOuts(ArrayRef<std::pair<StringAttr, int32_t>>) const:
+  # Assertion `getTotalOutDimSize() == std::accumulate( newOutDims.begin(), newOutDims.end(),
+  # 1, [&](int32_t acc, auto &outDim) { return acc * outDim.second; })' failed.
+  - hstu_triton_ragged_attention
   # presistent kernel is not ready for OSS
   - hstu_triton_ragged_attention_persistent
 # cpu-op for testing

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -9,6 +9,9 @@ flash_attention:
   - tk
   # triton_op_flash_v2 will segfault on triton-pytorch
   - triton_op_flash_v2
+  # force causal mode in backward
+  - triton_tutorial_flash_v2:
+      bwd_args: --causal
   # triton_tutorial_*_ws kernels require triton-main
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws
@@ -28,11 +31,6 @@ jagged_mean:
 jagged_softmax:
 jagged_sum:
 ragged_attention:
-  # ../../../lib/Tools/LinearLayout.cpp:565: LinearLayout
-  # mlir::triton::LinearLayout::reshapeOuts(ArrayRef<std::pair<StringAttr, int32_t>>) const:
-  # Assertion `getTotalOutDimSize() == std::accumulate( newOutDims.begin(), newOutDims.end(),
-  # 1, [&](int32_t acc, auto &outDim) { return acc * outDim.second; })' failed.
-  - hstu_triton_ragged_attention
   # presistent kernel is not ready for OSS
   - hstu_triton_ragged_attention_persistent
 # cpu-op for testing
@@ -40,3 +38,7 @@ test_op:
 # TODO: decoding attention requires updated xformers and flash_attn
 # Which will RAM OOM on the CI machine
 decoding_attention:
+bwd_args:
+  # flash_attention/triton_tutorial_flash_v2 does not support non-causal in backward
+  flash_attention:
+    - --causal

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -9,8 +9,6 @@ flash_attention:
   - tk
   # triton_op_flash_v2 will segfault on triton-pytorch
   - triton_op_flash_v2
-  # force causal mode in backward
-  - triton_tutorial_flash_v2
   # triton_tutorial_*_ws kernels require triton-main
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws

--- a/test/test_gpu/skip_tests_h100_pytorch.yaml
+++ b/test/test_gpu/skip_tests_h100_pytorch.yaml
@@ -10,8 +10,7 @@ flash_attention:
   # triton_op_flash_v2 will segfault on triton-pytorch
   - triton_op_flash_v2
   # force causal mode in backward
-  - triton_tutorial_flash_v2:
-      bwd_args: --causal
+  - triton_tutorial_flash_v2
   # triton_tutorial_*_ws kernels require triton-main
   - triton_tutorial_flash_v2_ws
   - triton_tutorial_flash_v2_tma_ws

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -26,11 +26,6 @@ jagged_mean:
 jagged_softmax:
 jagged_sum:
 ragged_attention:
-  # ../../../lib/Tools/LinearLayout.cpp:565: LinearLayout
-  # mlir::triton::LinearLayout::reshapeOuts(ArrayRef<std::pair<StringAttr, int32_t>>) const:
-  # Assertion `getTotalOutDimSize() == std::accumulate( newOutDims.begin(), newOutDims.end(),
-  # 1, [&](int32_t acc, auto &outDim) { return acc * outDim.second; })' failed.
-  - hstu_triton_ragged_attention
   # presistent kernel is not ready for OSS
   - hstu_triton_ragged_attention_persistent
 # cpu-op for testing
@@ -38,10 +33,7 @@ test_op:
 # TODO: decoding attention requires updated xformers and flash_attn
 # Which will RAM OOM on the CI machine
 decoding_attention:
-# FIXME: PT2 is broken with Triton-main
-launch_latency:
 addmm:
 gemm:
-flash_attention:
 gather_gemv:
 layer_norm:

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -42,3 +42,7 @@ addmm:
 gemm:
 gather_gemv:
 layer_norm:
+bwd_args:
+  # flash_attention/triton_tutorial_flash_v2 does not support non-causal in backward
+  flash_attention:
+    - --causal

--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -26,6 +26,11 @@ jagged_mean:
 jagged_softmax:
 jagged_sum:
 ragged_attention:
+  # ../../../lib/Tools/LinearLayout.cpp:565: LinearLayout
+  # mlir::triton::LinearLayout::reshapeOuts(ArrayRef<std::pair<StringAttr, int32_t>>) const:
+  # Assertion `getTotalOutDimSize() == std::accumulate( newOutDims.begin(), newOutDims.end(),
+  # 1, [&](int32_t acc, auto &outDim) { return acc * outDim.second; })' failed.
+  - hstu_triton_ragged_attention
   # presistent kernel is not ready for OSS
   - hstu_triton_ragged_attention_persistent
 # cpu-op for testing


### PR DESCRIPTION
With AWS auth, we no longer need to set up S3 secrets.
Enable more tests and add flash_attention backward with causal after the Triton version bump.