### PR TITLE
[ci] Re-enable layer_norm and gather_gemv in unit tests

### DIFF
--- a/test/test_gpu/skip_tests_h100_triton_main.yaml
+++ b/test/test_gpu/skip_tests_h100_triton_main.yaml
@@ -16,10 +16,10 @@ fp8_attention:
   - colfax_fmha
 # fb-only kernels
 fp8_fused_quant_gemm_rowwise:
-# gemm:
-#  # internal only kernels
-#   - hstu_triton_matmul
-#   - colfax_cutlass_matmul
+gemm:
+  # internal only kernels
+  - hstu_triton_matmul
+  - colfax_cutlass_matmul
 # jagged tests are slow, so disable them in OSS
 jagged_layer_norm:
 jagged_mean:
@@ -38,10 +38,6 @@ test_op:
 # TODO: decoding attention requires updated xformers and flash_attn
 # Which will RAM OOM on the CI machine
 decoding_attention:
-addmm:
-gemm:
-gather_gemv:
-layer_norm:
 bwd_args:
   # flash_attention/triton_tutorial_flash_v2 does not support non-causal in backward
   flash_attention:


### PR DESCRIPTION
Re-enable more tests.

Test Plan:
CI