### PR TITLE
Fix embedding_dim for fp8 attention

### DIFF
--- a/tritonbench/operators/fp8_attention/operator.py
+++ b/tritonbench/operators/fp8_attention/operator.py
@@ -41,7 +41,6 @@ def parse_op_args(args: List[str]):
     parser.add_argument(
         "--embedding-dim",
         type=int,
-        default=3072,
         help="specify embedding dim, embedding dim = n_heads * head_dim",
     )
     parser.add_argument("--n-heads", type=int, default=48, help="Number of heads")


### PR DESCRIPTION
Summary: By default we set `embedding_dim` to be 3072, but its not expected when ad_head` is also provided as an input to the benchmark resulting in a value error.

Differential Revision: D69881611


