### PR TITLE
Make Flex Benchmark more robust

### DIFF
--- a/tritonbench/operators/flex_attention/mods.py
+++ b/tritonbench/operators/flex_attention/mods.py
@@ -1,0 +1,193 @@
+from functools import partial
+from typing import List, Union
+
+import torch
+
+from torch._inductor.lowering import make_pointwise, register_lowering
+
+# Some internal torch.compile details
+from torch._inductor.virtualized import ops
+
+from torch.nn.attention.flex_attention import (
+    _mask_mod_signature,
+    _score_mod_signature,
+    and_masks,
+    or_masks,
+)
+
+Tensor = torch.Tensor
+
+
+def causal_mask(b, h, q_idx, kv_idx):
+    return q_idx >= kv_idx
+
+
+def _offsets_to_doc_ids_tensor(offsets):
+    device = offsets.device
+    counts = offsets[1:] - offsets[:-1]
+    return torch.repeat_interleave(
+        torch.arange(len(counts), device=device, dtype=torch.int32), counts
+    )
+
+
+def generate_alibi_bias(H: int) -> _score_mod_signature:
+    """Returns an alibi bias score_mod given the number of heads H
+
+    Args:
+        H: number of heads
+
+    Returns:
+        alibi_bias: alibi bias score_mod
+    """
+
+    def alibi_mod(score, b, h, q_idx, kv_idx):
+        scale = torch.exp2(-((h + 1) * 8.0 / H))
+        bias = (kv_idx - q_idx) * scale
+        return score + bias
+
+    return alibi_mod
+
+
+def length_to_offsets(lengths: List[int], device: Union[str, torch.device]) -> Tensor:
+    """Converts a list of lengths to a list of offsets.
+
+    Args:
+        lengths: A list of lengths.
+
+    """
+    offsets = [0]
+    offsets.extend(lengths)
+    offsets = torch.tensor(offsets, device=device, dtype=torch.int32)
+    offsets = torch.cumsum(offsets, dim=-1)
+    return offsets
+
+
+def generate_doc_mask_mod(
+    mask_mod: _mask_mod_signature, offsets: Tensor
+) -> _mask_mod_signature:
+    """Generates mask mods that apply to inputs to flex attention in the sequence stacked
+    format.
+
+    Args:
+        mask_mod: The mask mod to apply to the documents
+        offsets: This tensor should be of shape(num_documents + 1)
+            this should contain the cumulative counts of document tokens.
+            e.g. if you have 3 documents of length 2, 4, 3 then
+            offsets = [0, 2, 6, 9]
+
+    Note:
+        What is the sequence stacked format? When assembling batches of inputs, we
+        take multiple sequences and stack them together to form 1 large sequence. We then
+        use masking to ensure that the attention scores are only applied to tokens within
+        the same document.
+    """
+    document_id = _offsets_to_doc_ids_tensor(offsets)
+
+    def doc_mask_mod(b, h, q_idx, kv_idx):
+        same_doc = document_id[q_idx] == document_id[kv_idx]
+        q_logical = q_idx - offsets[document_id[q_idx]]
+        kv_logical = kv_idx - offsets[document_id[kv_idx]]
+        inner_mask = mask_mod(b, h, q_logical, kv_logical)
+        return same_doc & inner_mask
+
+    return doc_mask_mod
+
+
+def generate_prefix_lm_mask(prefix_length: int) -> _mask_mod_signature:
+    """Generates a prefix LM causal attention mask.
+
+    Args:
+        prefix_length: The length of the prefix.
+
+    Note:
+        This mask allows full attention within the prefix (first PREFIX_LENGTH tokens)
+        and causal attention for the rest of the sequence.
+    """
+
+    def prefix_mask(b, h, q_idx, kv_idx):
+        return kv_idx < prefix_length
+
+    prefix_lm_causal_mask = or_masks(prefix_mask, causal_mask)
+    prefix_lm_causal_mask.__name__ = f"prefix_lm_causal_mask_{prefix_length}"
+    return prefix_lm_causal_mask
+
+
+def generate_sliding_window(window_size: int) -> _mask_mod_signature:
+    """Generates a sliding window attention mask with a given window size.
+    Args:
+        window_size: The size of the sliding window.
+
+    Note:
+        We assume that the window size represents the lookback size and we mask out all future tokens
+        similar to causal masking.
+    """
+
+    def sliding_window(b, h, q_idx, kv_idx):
+        return q_idx - kv_idx <= window_size
+
+    sliding_window_mask = and_masks(sliding_window, causal_mask)
+    sliding_window_mask.__name__ = f"sliding_window_{window_size}"
+    return sliding_window_mask
+
+
+@torch.library.custom_op("approx::tanh", mutates_args=())
+def _tanh_approx(inp: Tensor) -> Tensor:
+    return torch.tanh(inp)
+
+
+@_tanh_approx.register_fake
+def _(inp: torch.Tensor) -> torch.Tensor:
+    return torch.tanh(inp)
+
+
+def _tanh_approx_lowering(inp):
+    fn = partial(ops.inline_asm_elementwise, asm="tanh.approx.f32 $0, $1;")
+    return make_pointwise(fn)(inp)
+
+
+register_lowering(torch.ops.approx.tanh)(_tanh_approx_lowering)
+
+
+class _TanhApprox(torch.autograd.Function):
+    @staticmethod
+    def forward(x):
+        return torch.ops.approx.tanh(x)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        (x,) = inputs
+        result = output
+        ctx.save_for_backward(result)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (result,) = ctx.saved_tensors
+        return grad_output * (1 - result * result)
+
+    @staticmethod
+    def vmap(info, in_dims, x):
+        return torch.tanh(x), 0
+
+
+_tanh_approx = _TanhApprox.apply
+
+
+def generate_tanh_softcap(soft_cap: int, approx: bool = False) -> _score_mod_signature:
+    """Returns an tanh bias score_mod given the number of heads H
+
+    Args:
+        soft_cap: The soft cap value to use for normalizing logits
+        approx: Whether to use the `tanh.approx.` ptx instruction
+
+    Returns:
+        tanh_softcap: score_mod
+    """
+    tanh = _tanh_approx if approx else torch.tanh
+
+    def tanh_softcap(score, b, h, q_idx, kv_idx):
+        return soft_cap * tanh(score / soft_cap)
+
+    prefix = "tanh_softcap_approx" if approx else "tanh_softcap"
+    tanh_softcap.__name__ = f"{prefix}_{soft_cap}"
+
+    return tanh_softcap

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -1,8 +1,25 @@
 import argparse
-from typing import Callable, Generator, List, Optional, Tuple
+import random
+from functools import partial
+from itertools import product
+from typing import Any, Callable, Generator, List, NamedTuple, Optional, Tuple, Union
 
 import torch
-from torch.nn.attention.flex_attention import flex_attention
+
+from attn_gym.masks import (
+    generate_doc_mask_mod,
+    generate_prefix_lm_mask,
+    generate_sliding_window,
+)
+from attn_gym.masks.causal import causal_mask
+from attn_gym.masks.document_mask import length_to_offsets
+from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
+from torch.nn.attention.flex_attention import (
+    _score_mod_signature,
+    BlockMask,
+    create_block_mask,
+    flex_attention,
+)
 
 from tritonbench.utils.input import input_filter
 from tritonbench.utils.triton_op import (
@@ -14,110 +31,234 @@ from tritonbench.utils.triton_op import (
     register_x_val,
 )
 
-# Default configurations for the benchmark
-BATCH_SIZE = 8
-NUM_HEADS = 16
-SEQ_LEN = 1024
-HEAD_DIM = 128
-DTYPE = torch.bfloat16
+try:
+    import attn_gym  # noqa: F401
+except ImportError as e:
+    print(
+        "attn_gym not found, to install run `pip install git+https://github.com/pytorch-labs/attention-gym.git`"
+    )
+    raise e
+
+# TODO how should I enable these
+# torch._dynamo.config.automatic_dynamic_shapes = False
+# torch._dynamo.config.recompile_limit = 10000
+# torch._dynamo.config.accumulated_recompile_limit = 10000
+
+MOD_TYPES = [
+    "noop",
+    "causal",
+    "rel",
+    "head_bias",
+    "alibi",
+    "sliding_window",
+    "document_mask",
+    "prefix_lm",
+    "softcap",
+]
+
+
+class FullShape(NamedTuple):
+    B: int
+    Hq: int
+    M: int
+    Hkv: int
+    N: int
+    D: int
+
+    def __str__(self):
+        return f"({self.B}, {self.Hq}, {self.M}, {self.Hkv}, {self.N}, {self.D})"
+
+
+def parse_op_args(args: List[str]):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=8, help="Batch size")
+    parser.add_argument("--seq-len", type=int, default=None, help="Sequence length")
+    parser.add_argument("--n-heads", type=int, default=16, help="Number of heads")
+    parser.add_argument(
+        "--d-head", type=int, default=128, help="specify head dimension"
+    )
+    allowed_mods = MOD_TYPES + ["all"]
+    parser.add_argument(
+        "--mod-type",
+        type=str,
+        default="noop",
+        choices=allowed_mods,
+        help="Mask type",
+    )
+    parser.add_argument(
+        "--max-autotune", action="store_true", help="Whether to enable max autotune"
+    )
+    parser.add_argument(
+        "--sliding-window-size", type=int, default=128, help="sliding window size"
+    )
+    parser.add_argument("--prefix-length", type=int, default=128, help="prefix length")
+    return parser.parse_args(args)
 
 
 class Operator(BenchmarkOperator):
     DEFAULT_PRECISION = "bf16"
+    DEFAULT_METRICS = ["latency", "tflops"]
 
     def __init__(
         self, tb_args: argparse.Namespace, extra_args: Optional[List[str]] = None
     ):
         super().__init__(tb_args, extra_args)
-        self.batch_size = BATCH_SIZE
-        self.seq_len = SEQ_LEN
-        self.head_dim = HEAD_DIM
-        self.num_heads = NUM_HEADS
+        args = parse_op_args(self.extra_args)
+
+        self.batch_size = args.batch
+        self.seq_len = args.seq_len
+        self.num_heads = args.n_heads
+        self.head_dim = args.d_head
+        self.max_autotune = args.max_autotune
+        self.mod_type = args.mod_type
+        self.sliding_window_size = args.sliding_window_size
+        self.prefix_length = args.prefix_length
 
     def get_input_iter(self) -> Generator:
         """Generate a single input configuration for benchmarking."""
 
-        # Create query, key, value tensors
-        q = torch.rand(
-            self.batch_size,
-            self.num_heads,
-            self.seq_len,
-            self.head_dim,
-            device="cuda",
-            dtype=DTYPE,
-            requires_grad=True,
-        )
-        k = torch.rand(
-            self.batch_size,
-            self.num_heads,
-            self.seq_len,
-            self.head_dim,
-            device="cuda",
-            dtype=DTYPE,
-            requires_grad=True,
-        )
-        v = torch.rand(
-            self.batch_size,
-            self.num_heads,
-            self.seq_len,
-            self.head_dim,
-            device="cuda",
-            dtype=DTYPE,
-            requires_grad=True,
-        )
+        def get_ctx_vals():
+            if self.seq_len:
+                q_shape = (self.batch_size, self.num_heads, self.seq_len, self.head_dim)
+                kv_shape = (
+                    self.batch_size,
+                    self.num_heads,
+                    self.seq_len,
+                    self.head_dim,
+                )
+                yield (q_shape, kv_shape)
+                return
+            # 128 -> 32768
+            for i in range(7, 15):
+                seq_len = 2**i
+                q_shape = (self.batch_size, self.num_heads, seq_len, self.head_dim)
+                kv_shape = (self.batch_size, self.num_heads, seq_len, self.head_dim)
+                yield (q_shape, kv_shape)
 
-        # Default kernel options for flex_attention
-        kernel_options = {
-            "num_warps": 8,
-            # "ENABLE_TMA": True,
-            # "TMA_SIZE": 128,
-            "BLOCK_M": 128,
-            "BLOCK_N": 128,
-        }
+        shapes = get_ctx_vals()
+        mask_mods = MOD_TYPES if self.mod_type == "all" else [self.mod_type]
 
-        yield (
-            q,
-            k,
-            v,
-            kernel_options,
-        )
+        for (q_shape, kv_shape), mod_type in product(shapes, mask_mods):
+            full_shape = self.get_full_shape(q_shape, kv_shape)
+            block_mask, mask_mod_kwargs = self.generate_block_mask(
+                mod_type, full_shape, self.sliding_window_size, self.prefix_length
+            )
+            score_mod = self.generate_score_mod(mod_type, full_shape)
+            B, Hq, M, Hkv, N, D = full_shape
+            if mod_type == "document_mask":
+                q_shape_packed = (1, Hq, M * B, D)
+                kv_shape_packed = (1, Hkv, N * B, D)
+            else:
+                q_shape_packed = q_shape
+                kv_shape_packed = kv_shape
 
-    @register_x_val(label="(Batch, Heads, SeqLen, Dhead)")
-    def get_x_val(self, args) -> str:
-        """Return a string representation of the input configuration."""
-        q, k, v, *_ = args
+            make_q = partial(
+                torch.rand,
+                q_shape_packed,
+                device=self.device,
+                dtype=self.dtype,
+                requires_grad=self.requires_grad,
+            )
+            make_kv = partial(
+                torch.rand,
+                kv_shape_packed,
+                device=self.device,
+                dtype=self.dtype,
+                requires_grad=self.requires_grad,
+            )
+
+            q = make_q()
+            k = make_kv()
+            v = make_kv()
+
+            # Default kernel options for flex_attention
+            kernel_options = self.get_kernel_options(mod_type, full_shape)
+            yield (
+                q,
+                k,
+                v,
+                score_mod,
+                block_mask,
+                mod_type,
+                kernel_options,
+            )
+
+    @register_x_val(label="(B, Hq, M, Hkv, N, D) | Mask Type")
+    def get_x_val(self, example_inputs) -> str:
+        """Return a detailed string representation of the input configuration."""
+        q, k, v, score_mod, block_mask, mod_type, *_ = example_inputs
         B, H, S, D = q.shape
-        return (B, H, S, D)
+
+        shape = self.get_full_shape(q, v)
+        return f"{str(shape):>30} | {mod_type:>15}"
 
     @register_benchmark(baseline=True)
     def eager(
         self,
-        q,
-        k,
-        v,
-        kernel_options,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        score_mod: Optional[_score_mod_signature],
+        block_mask: Optional[BlockMask],
+        mod_type: str,
+        kernel_options: dict[str, Any],
     ) -> Callable:
         """Baseline implementation using eager mode."""
-        return lambda: flex_attention(q, k, v)
+        # Get shape information
+        B, H, S, D = q.shape
+
+        # Check if we should skip based on criteria
+        should_skip = False
+        if mod_type == "document_mask" and B * S >= 4096:
+            should_skip = True
+            print(
+                f"Skipping eager for document_mask with batch*seq_len={B * S} >= 4096"
+            )
+        elif mod_type != "document_mask" and S > 8192:
+            should_skip = True
+            print(f"Skipping eager for {mod_type} with seq_len={S} > 8192")
+
+        # If should skip, return a function that raises an exception
+        if should_skip:
+            # TODO  Figure out a way to skip the bigger shapes that will oom w/ eager
+            pass
+
+        # Otherwise return the normal function
+        return lambda: flex_attention(
+            q, k, v, block_mask=block_mask, kernel_options=kernel_options
+        )
 
     @register_benchmark()
     def compiled(
         self,
-        q,
-        k,
-        v,
-        kernel_options,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        score_mod: Optional[_score_mod_signature],
+        block_mask: Optional[BlockMask],
+        mod_type: str,
+        kernel_options: dict[str, Any],
     ) -> Callable:
         """Compiled implementation using torch.compile."""
-        compiled_fn = torch.compile(flex_attention, fullgraph=True)
-        return lambda: compiled_fn(q, k, v, kernel_options=kernel_options)
+        mode = "default" if not self.max_autotune else "max-autotune-no-cudagraphs"
+        compiled_fn = torch.compile(flex_attention, fullgraph=True, mode=mode)
+
+        return lambda: compiled_fn(
+            q,
+            k,
+            v,
+            score_mod=score_mod,
+            block_mask=block_mask,
+            kernel_options=kernel_options,
+        )
 
     def get_bwd_fn(self, fwd_fn: Callable) -> Callable:
         o = fwd_fn()
         o_tensor = input_filter(
-            lambda x: isinstance(x, torch.Tensor),
+            lambda x: isinstance(x, torch.Tensor) and x.requires_grad,
             o,
         )
+        assert o_tensor is not None, "No tensor found in output that requires grad."
         do = torch.rand_like(o_tensor)
         return lambda: o_tensor.backward(do, retain_graph=True)
 
@@ -131,12 +272,250 @@ class Operator(BenchmarkOperator):
         self, fn_name: str, example_inputs: Tuple, metrics: BenchmarkOperatorMetrics
     ) -> float:
         """Calculate the number of floating point operations for flex_attention."""
-        q, *_ = example_inputs
+        q, k, v, score_mod, block_mask, mod_type, *_ = example_inputs
         BATCH, H, N_CTX, D_HEAD = q.shape
+        full_shape = self.get_full_shape(q, v)
         flops_per_matmul = 2.0 * BATCH * H * N_CTX * N_CTX * D_HEAD
         flops = 2 * flops_per_matmul
+        if self.mode in (BenchmarkMode.FWD, BenchmarkMode.FWD_NO_GRAD):
+            if fn_name == "compiled":
+                return self.calculate_flops(full_shape, block_mask)
+            return flops
         if self.mode == BenchmarkMode.BWD:
             flops *= 2.5  # 2.0(bwd) + 0.5(recompute)
         elif self.mode == BenchmarkMode.FWD_BWD:
             flops *= 3.5  # 1.0(fwd) + 2.0(bwd) + 0.5(recompute)
         return flops
+
+    ### -------------------- Utilities for benchmarking ------------------- ###
+    @staticmethod
+    def calculate_flops(shape: FullShape, block_mask: BlockMask) -> float:
+        (B, Hq, M, Hkv, N, D) = shape
+        qk_flops = M * N * D * 2
+        softmax_flops = M * N * 2  # Not counting online softmax overhead
+        o_flops = M * D * N * 2
+        # Not counting split k overhead
+        sparsity = block_mask.sparsity() / 100.0 if block_mask is not None else 0.0
+        total_flops = B * Hq * (qk_flops + softmax_flops + o_flops) * (1 - sparsity)
+        return total_flops
+
+    # @staticmethod
+    # def calculate_bandwidth(shape: FullShape, block_mask: BlockMask) -> float:
+    #     B, Hq, M, Hkv, N, D = shape
+    #     sparsity = results.sparsity if M == 1 else 0.0
+    #     if type == "fwd":
+    #         batch_size, q_heads, q_seq_len, kv_heads, kv_seq_len, head_dim = config.shape
+    #         query_size = (
+    #             batch_size
+    #             * q_heads
+    #             * q_seq_len
+    #             * head_dim
+    #             * torch.finfo(config.dtype).bits
+    #             / 8
+    #         )
+    #         kv_size = (
+    #             batch_size
+    #             * kv_heads
+    #             * kv_seq_len
+    #             * head_dim
+    #             * torch.finfo(config.dtype).bits
+    #             / 8
+    #             * 2
+    #         )
+    #         output_size = query_size
+    #         total_size = (
+    #             query_size + kv_size * (1 - sparsity) + output_size
+    #         ) / 1e9  # In GB
+    #         time_in_seconds = results.fwd_time / 1e6
+    #         return total_size / time_in_seconds / 1e3
+    #     else:
+    #         raise ValueError(f"Invalid type {type}")
+
+    @staticmethod
+    def get_full_shape(
+        q: Union[torch.Tensor, Tuple[int, int, int, int]],
+        v: Union[torch.Tensor, Tuple[int, int, int, int]],
+    ) -> FullShape:
+        """
+        Get the full shape information from q and v tensors or their shape tuples.
+
+        Overloaded to accept either:
+        1. Two torch.Tensor objects
+        2. Two shape tuples (B, Hq, M, D) and (B, Hkv, N, D_V)
+
+        Returns:
+            FullShape(B, Hq, M, Hkv, N, D)
+        """
+        if isinstance(q, torch.Tensor) and isinstance(v, torch.Tensor):
+            B, Hq, M, D = q.shape
+            B_v, Hkv, N, D_V = v.shape
+            assert B == B_v, "Batch sizes must match"
+            return FullShape(B, Hq, M, Hkv, N, D)
+        elif isinstance(q, tuple) and isinstance(v, tuple):
+            assert len(q) == 4, "q shape must be (B, Hq, M, D)"
+            assert len(v) == 4, "v shape must be (B, Hkv, N, D_V)"
+            B, Hq, M, D = q
+            B_v, Hkv, N, D_V = v
+            assert B == B_v, "Batch sizes must match"
+            return FullShape(B, Hq, M, Hkv, N, D)
+        else:
+            raise TypeError(
+                "Inputs must be either two torch.Tensor objects or two shape tuples"
+            )
+
+    @staticmethod
+    def get_kernel_options(attn_type: str, shape: FullShape):
+        B, Hq, M, Hkv, N, D = shape
+        is_decoding = M == 1
+        # TODO add ways to specify TMA and warp spec
+        # "ENABLE_TMA": True,
+        kernel_opt_training_dict = {
+            "noop": None,
+            "causal": None,
+            "rel": None,
+            "head_bias": None,
+            "alibi": None,
+            "sliding_window": None,
+            "document_mask": {
+                "BLOCK_N": 32,
+                "BLOCK_M": 128,
+                "fwd_num_warps": 8,
+                "fwd_num_stages": 4,
+                "BLOCK_M1": 64,
+                "BLOCK_N1": 64,
+                "BLOCK_M2": 64,
+                "BLOCK_N2": 64,
+            }
+            if torch.cuda.get_device_capability() >= (8, 0) and D <= 128
+            else None,
+            "prefix_lm": None,
+            "softcap": None,
+        }
+
+        def get_default_split_k(B: int, H: int, Mk: int) -> int:
+            num_SM = torch.cuda.get_device_properties("cuda").multi_processor_count
+            """Heuristic for the number of splits from xformer"""
+            bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
+            split_k = num_SM // bh * 2  # Each SM should at least get one block.
+            split_k = max(split_k, 1)
+
+            return split_k
+
+        kernel_opt_decoding_dict = {
+            "noop": None,
+            "causal": {"SPLIT_KV": get_default_split_k(B, Hkv, N) * 2},
+            "rel": None,
+            "head_bias": None,
+            "alibi": {"SPLIT_KV": get_default_split_k(B, Hkv, N) * 2},
+            "sliding_window": None,
+            "document_mask": None,
+            "prefix_lm": None,
+            "softcap": {"SPLIT_KV": get_default_split_k(B, Hkv, N) * 2},
+        }
+
+        return (
+            kernel_opt_decoding_dict[attn_type]
+            if is_decoding
+            else kernel_opt_training_dict[attn_type]
+        )
+
+    @staticmethod
+    def generate_block_mask(
+        attn_type: str, shape: FullShape, sliding_window_size: int, prefix_length: int
+    ):
+        B, Hq, M, Hkv, N, D = shape
+        is_decoding = M == 1
+
+        def generate_random_lengths(total_length: int, num_documents: int):
+            # Initialize all lengths to 1 to ensure each document has at least one token
+            lengths = [1] * num_documents
+            remaining_length = total_length - num_documents
+
+            # Randomly distribute the remaining length
+            for _ in range(remaining_length):
+                index = random.randint(0, num_documents - 1)
+                lengths[index] += 1
+            return lengths
+
+        mask_mod_kwargs = {}
+
+        assert attn_type != "document_mask" or not is_decoding
+        if attn_type == "document_mask":
+            random.seed(0)
+            lengths = generate_random_lengths(N * B, B)
+            mask_mod_kwargs = dict(offsets=length_to_offsets(lengths, "cuda"))
+
+        mask_mod_dict = {
+            "noop": None,
+            "causal": causal_mask,
+            "rel": None,
+            "head_bias": None,
+            "alibi": causal_mask,
+            "sliding_window": generate_sliding_window(sliding_window_size),
+            "document_mask": partial(generate_doc_mask_mod, mask_mod=causal_mask),
+            "prefix_lm": generate_prefix_lm_mask(prefix_length),
+            "softcap": causal_mask,
+        }
+
+        mask_mod = mask_mod_dict[attn_type]
+
+        if mask_mod_kwargs:
+            mask_mod = mask_mod(**mask_mod_kwargs)
+
+        if is_decoding and mask_mod:
+            cached_seq_len = torch.tensor(N // 2).to("cuda")
+
+            def decoding_w_cached_seq_len(b, h, m, n):
+                return mask_mod(b, h, m + cached_seq_len, n)
+
+            new_mask_mod = decoding_w_cached_seq_len
+        else:
+            new_mask_mod = mask_mod
+
+        mask_shape = (
+            (1, 1, M, N) if attn_type != "document_mask" else (1, 1, M * B, N * B)
+        )
+        compiled_block_mask = torch.compile(create_block_mask)
+        block_mask = (
+            compiled_block_mask(new_mask_mod, *mask_shape, "cuda")
+            if new_mask_mod
+            else None
+        )
+        return block_mask, mask_mod_kwargs
+
+    @staticmethod
+    def generate_score_mod(attn_type: str, shape: FullShape) -> Callable | None:
+        _, Hq, M, _, N, _ = shape
+        is_decoding = M == 1
+
+        def relative_bias(score, b, h, m, n):
+            return score + (m - n)
+
+        def head_bias(score, b, h, m, n):
+            return score + 2 * h
+
+        function_dict = {
+            "noop": None,
+            "causal": None,
+            "rel": relative_bias,
+            "head_bias": head_bias,
+            "alibi": generate_alibi_bias(Hq),
+            "sliding_window": None,
+            "document_mask": None,
+            "prefix_lm": None,
+            "softcap": generate_tanh_softcap(20, approx=True),
+        }
+
+        score_mod = function_dict[attn_type]
+        is_decoding = M == 1
+        if is_decoding and score_mod:
+            offset = torch.tensor(N // 2).to("cuda")
+
+            def score_mod_w_offset(score, b, h, m, n):
+                return score_mod(score, b, h, m + offset, n)
+
+            new_score_mod = score_mod_w_offset
+        else:
+            new_score_mod = score_mod
+
+        return new_score_mod

--- a/tritonbench/operators/flex_attention/operator.py
+++ b/tritonbench/operators/flex_attention/operator.py
@@ -6,14 +6,8 @@ from typing import Any, Callable, Generator, List, NamedTuple, Optional, Tuple, 
 
 import torch
 
-from attn_gym.masks import (
-    generate_doc_mask_mod,
-    generate_prefix_lm_mask,
-    generate_sliding_window,
-)
-from attn_gym.masks.causal import causal_mask
-from attn_gym.masks.document_mask import length_to_offsets
-from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
+# from attn_gym.masks.document_mask import length_to_offsets
+# from attn_gym.mods import generate_alibi_bias, generate_tanh_softcap
 from torch.nn.attention.flex_attention import (
     _score_mod_signature,
     BlockMask,
@@ -31,13 +25,16 @@ from tritonbench.utils.triton_op import (
     register_x_val,
 )
 
-try:
-    import attn_gym  # noqa: F401
-except ImportError as e:
-    print(
-        "attn_gym not found, to install run `pip install git+https://github.com/pytorch-labs/attention-gym.git`"
-    )
-    raise e
+from .mods import (
+    causal_mask,
+    generate_alibi_bias,
+    generate_doc_mask_mod,
+    generate_prefix_lm_mask,
+    generate_sliding_window,
+    generate_tanh_softcap,
+    length_to_offsets,
+)
+
 
 torch._dynamo.config.automatic_dynamic_shapes = False
 torch._dynamo.config.recompile_limit = 10000

--- a/tritonbench/utils/input.py
+++ b/tritonbench/utils/input.py
@@ -1,4 +1,5 @@
 import torch
+from torch.nn.attention.flex_attention import BlockMask
 from torch.utils._pytree import tree_map
 
 
@@ -19,6 +20,11 @@ def input_cast(cond, action, example_inputs):
     elif isinstance(example_inputs, torch.Tensor):
         return example_inputs
     elif isinstance(example_inputs, torch.nn.Module):
+        return example_inputs
+    elif isinstance(example_inputs, BlockMask):
+        return example_inputs
+    # FlexAttention passes around functions as inputs
+    elif callable(example_inputs):
         return example_inputs
     else:
         raise RuntimeError(f"Unsupported input type: {type(example_inputs)}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #195
* __->__ #194
* #193

# Summary
Adds alot more options to FlexAttention in preparation for integration into PyTorch CI

``` Shell
python run.py --op flex_attention --mod-type all
torch._dynamo.exc.FailOnRecompileLimitHit: recompile_limit reached with one_graph=True. Excessive recompilations can degrade performance due to the compilation overhead of each recompilation. To monitor recompilations, enable TORCH_LOGS=recompiles. If recompilations are expected, consider increasing torch._dynamo.config.cache_size_limit to an appropriate value.
             (B, Hq, M, Hkv, N, D) | Mask Type       eager-latency    eager-tflops    compiled-latency    compiled-tflops
----------------------------------------------  ------------------  --------------  ------------------  -----------------
(8, 16, 1024, 16, 1024, 128) |            noop   6.148416 (±0.14%)         11.1768   0.311456 (±4.33%)           221.501
(8, 16, 1024, 16, 1024, 128) |          causal   6.023616 (±5.64%)         11.4083   0.216096 (±1.16%)           179.576
(8, 16, 1024, 16, 1024, 128) |             rel  6.437376 (±14.75%)         10.6751   0.315424 (±0.46%)           218.715
(8, 16, 1024, 16, 1024, 128) |       head_bias   6.150592 (±0.81%)         11.1728   0.313856 (±4.37%)           219.808
(8, 16, 1024, 16, 1024, 128) |           alibi   6.021952 (±0.20%)         11.4115   0.231264 (±4.14%)           167.798
(8, 16, 1024, 16, 1024, 128) |  sliding_window   6.111872 (±8.38%)         11.2436   0.145600 (±0.84%)           111.051
(1, 16, 8192, 16, 8192, 128) |   document_mask  51.003872 (±0.00%)         10.7787   0.754976 (±0.56%)            61.5728
(8, 16, 1024, 16, 1024, 128) |       prefix_lm   6.116736 (±0.09%)         11.2347   0.238304 (±0.87%)           162.841
                                       average                             11.1377                               167.858
 ```
 
 ```Shell
 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:10<00:00,  1.33s/it]
               (B, Hq, M, Hkv, N, D) | Mask Type       eager-latency    eager-tflops    compiled-latency    compiled-tflops
------------------------------------------------  ------------------  --------------  ------------------  -----------------
    (8, 16, 128, 16, 128, 128) |            noop   4.532608 (±3.04%)        0.236893   0.033888 (±6.23%)            31.8088
    (8, 16, 256, 16, 256, 128) |            noop   4.745440 (±7.32%)        0.905073  0.062336 (±50.87%)            69.1694
    (8, 16, 512, 16, 512, 128) |            noop   4.604416 (±3.73%)        3.73117    0.119552 (±3.29%)           144.263
  (8, 16, 1024, 16, 1024, 128) |            noop   6.161120 (±0.11%)       11.1537     0.347584 (±0.41%)           198.478
  (8, 16, 2048, 16, 2048, 128) |            noop  23.343552 (±0.13%)       11.7753     1.196704 (±0.20%)           230.593
  (8, 16, 4096, 16, 4096, 128) |            noop  93.069984 (±0.00%)       11.8138     4.523712 (±0.05%)           244.005
  (8, 16, 8192, 16, 8192, 128) |            noop            CUDA OOM                  16.141216 (±5.77%)           273.537
(8, 16, 16384, 16, 16384, 128) |            noop            CUDA OOM                  63.646015 (±0.00%)           277.486
                                         average                           73.83                                   114.79
```

Differential Revision: [D73006208](https://our.internmc.facebook.com/intern/diff/D73006208)