### PR TITLE
[backends] Fix ThunderKittens and enable backward

### DIFF
--- a/tools/tk/tk.patch
+++ b/tools/tk/tk.patch
@@ -2,10 +2,11 @@ diff --git a/config.py b/config.py
 index 0d97ed8..cedf943 100644
 --- a/config.py
 +++ b/config.py
-@@ -60,7 +60,7 @@ sources = {
+@@ -68,7 +68,7 @@ sources = {
  ### WHICH KERNELS DO WE WANT TO BUILD?
  # (oftentimes during development work you don't need to redefine them all.)
--kernels = ['attn', 'mamba2', 'hedgehog', 'fftconv', 'fused_rotary', 'based', 'fused_layernorm']
+ # kernels = ['attn', 'mamba2', 'hedgehog', 'fftconv', 'fused_rotary', 'based', 'fused_layernorm']
+-kernels = ['fp8_gemm']
 +kernels = ['attn', 'fp8_gemm']
 
  ### WHICH GPU TARGET DO WE WANT TO BUILD FOR?

--- a/tools/tk/tk.patch
+++ b/tools/tk/tk.patch
@@ -2,12 +2,11 @@ diff --git a/config.py b/config.py
 index 0d97ed8..cedf943 100644
 --- a/config.py
 +++ b/config.py
-@@ -63,7 +63,7 @@ sources = {
+@@ -60,7 +60,7 @@ sources = {
  ### WHICH KERNELS DO WE WANT TO BUILD?
  # (oftentimes during development work you don't need to redefine them all.)
- # kernels = ['attn', 'mamba2', 'hedgehog', 'fftconv', 'fused_rotary', 'based', 'fused_layernorm']
--kernels = ['fp8_gemm']
+-kernels = ['attn', 'mamba2', 'hedgehog', 'fftconv', 'fused_rotary', 'based', 'fused_layernorm']
 +kernels = ['attn', 'fp8_gemm']
- 
+
  ### WHICH GPU TARGET DO WE WANT TO BUILD FOR?
  target = 'h100'

--- a/tritonbench/operators/flash_attention/tk.py
+++ b/tritonbench/operators/flash_attention/tk.py
@@ -1,0 +1,38 @@
+from typing import Tuple
+
+import thunderkittens as tk
+import torch
+
+
+class _TKAttn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, causal) -> torch.Tensor:
+        saved_tensors = [q, k, v]
+        ctx.save_for_backward(*saved_tensors)
+        ctx.causal = causal
+        return tk.mha_forward(q, k, v, causal)
+
+    @staticmethod
+    def backward(ctx, do) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, None]:
+        causal = ctx.causal
+        q, k, v = ctx.saved_tensors
+        o = torch.zeros_like(q).contiguous()
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        l_vec = torch.zeros(
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            1,
+            device=q.device,
+            dtype=torch.float,
+            requires_grad=False,
+        ).contiguous()
+        dq, dk, dv = tk.mha_backward(q, k, v, o, l_vec, do, causal)
+        return dq, dk, dv, None
+
+
+def tk_attn(q, k, v, causal) -> torch.Tensor:
+    o = _TKAttn.apply(q, k, v, causal)
+    return o

--- a/tritonbench/operators/flash_attention/tk.py
+++ b/tritonbench/operators/flash_attention/tk.py
@@ -7,28 +7,19 @@ import torch
 class _TKAttn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, q, k, v, causal) -> torch.Tensor:
-        saved_tensors = [q, k, v]
-        ctx.save_for_backward(*saved_tensors)
         ctx.causal = causal
-        return tk.mha_forward(q, k, v, causal)
+        o, l_vec = tk.mha_forward(q, k, v, causal)
+        saved_tensors = [q, k, v, o, l_vec]
+        ctx.save_for_backward(*saved_tensors)
+        return o
 
     @staticmethod
     def backward(ctx, do) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, None]:
         causal = ctx.causal
-        q, k, v = ctx.saved_tensors
-        o = torch.zeros_like(q).contiguous()
+        q, k, v, o, l_vec = ctx.saved_tensors
         dq = torch.empty_like(q)
         dk = torch.empty_like(k)
         dv = torch.empty_like(v)
-        l_vec = torch.zeros(
-            q.shape[0],
-            q.shape[1],
-            q.shape[2],
-            1,
-            device=q.device,
-            dtype=torch.float,
-            requires_grad=False,
-        ).contiguous()
         dq, dk, dv = tk.mha_backward(q, k, v, o, l_vec, do, causal)
         return dq, dk, dv, None
 


### PR DESCRIPTION
Update ThunderKittens to the latest version.
* Fix the patch to include fp8_gemm and attn kernels.
* Enable backward pass for ThunderKittens

Test Plan:

```
$ python run.py --op flash_attention --only flash_v3,tk  --bwd --metrics tflops

  (Batch, Heads, SeqLen, Dhead)    flash_v3-tflops    tk-tflops
-------------------------------  -----------------  -----------
               (4, 48, 128, 64)            29.3719      17.4666
               (4, 48, 256, 64)            72.7126      47.7802
               (4, 48, 512, 64)           140.591       94.6528
              (4, 48, 1024, 64)           242.548      168.82
              (4, 48, 2048, 64)           336.969      249.502
              (4, 48, 4096, 64)           405.168      317.415
              (4, 48, 8192, 64)           444.253      365.432
             (4, 48, 16384, 64)           468.285      379.583
                        average           267.487      205.082
```