### PR TITLE
Append Triton type to Scuba table logging

### DIFF
--- a/run.py
+++ b/run.py
@@ -64,6 +64,8 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
 
             if "hardware" in args:
                 kwargs["hardware"] = args.hardware
+            if "triton_type" in args:
+                kwargs["triton_type"] = args.triton_type
             log_benchmark(**kwargs)
 
         if args.plot:


### PR DESCRIPTION
Summary: Adds the logic to include a new column, `triton_type` to the scuba table for benchmark logging. This column will be used to track which version of Triton is used in experiments/testing. Currenlty this will be stable and trunk, but in the future may include the trunk + semantic patch version.

Differential Revision: D72975732


