### PR TITLE
[input_loader] Only load input loader in fbcode

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -752,7 +752,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     # Run the post initialization
     def __post__init__(self):
-        if self.tb_args.input_loader:
+        if is_fbcode() and self.tb_args.input_loader:
             from tritonbench.data.fb.input_loader import get_input_loader
 
             self.get_input_iter = get_input_loader(


### PR DESCRIPTION
https://github.com/pytorch-labs/tritonbench/commit/d4a1e60650d332d516bf62aca3aba196271a85d1 broke the code for OSS, fixing it.