### PR TITLE
[run_utils] Support running benchmark with config file

### DIFF
--- a/benchmarks/run_config/example_config.yaml
+++ b/benchmarks/run_config/example_config.yaml
@@ -1,3 +1,3 @@
 benchmarks:
   - benchmark_name: bf16_ragged_attention_fwd
-    args: --op ragged_attention --only hstu --num-inputs 1 --input-id 2 --metrics tflops --cudagraph
+    args: --op ragged_attention --only hstu --num-inputs 1 --input-id 2 --metrics tflops --cudagraph --simple-output

--- a/benchmarks/run_config/example_config.yaml
+++ b/benchmarks/run_config/example_config.yaml
@@ -1,0 +1,3 @@
+benchmarks:
+  - benchmark_name: bf16_ragged_attention_fwd
+    args: --op ragged_attention --only hstu_triton --num-inputs 1 --input-id 4 --metrics tflops --cudagraph

--- a/benchmarks/run_config/example_config.yaml
+++ b/benchmarks/run_config/example_config.yaml
@@ -1,3 +1,3 @@
 benchmarks:
   - benchmark_name: bf16_ragged_attention_fwd
-    args: --op ragged_attention --only hstu_triton --num-inputs 1 --input-id 4 --metrics tflops --cudagraph
+    args: --op ragged_attention --only hstu --num-inputs 1 --input-id 2 --metrics tflops --cudagraph

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,8 +2,9 @@
 
 # Entrypoint of the docker image
 
+# shellcheck source=/workspace/setup_instance.sh
 . "${SETUP_SCRIPT}"
 
-cd /workspace/tritonbench
+cd /workspace/tritonbench || exit
 
 python run.py

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Entrypoint of the docker image
+
+. "${SETUP_SCRIPT}"
+
+cd /workspace/tritonbench
+
+python run.py

--- a/docker/tritonbench-nightly.dockerfile
+++ b/docker/tritonbench-nightly.dockerfile
@@ -66,3 +66,6 @@ RUN sudo apt-get purge -y libnvidia-compute-550
 # Clone the pytorch env as triton-main env, then compile triton main from source
 RUN cd /workspace/tritonbench && \
     BASE_CONDA_ENV=${CONDA_ENV} CONDA_ENV=${CONDA_ENV_TRITON_MAIN} bash .ci/tritonbench/install-triton-main.sh
+
+# Set run command
+CMD ["bash", "/workspace/tritonbench/docker/entrypoint.sh"]

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.gpu_utils import gpu_lockdown
 from tritonbench.utils.parser import get_parser
-from tritonbench.utils.run_utils import run_in_task
+from tritonbench.utils.run_utils import run_in_task, run_config
 
 from tritonbench.utils.triton_op import BenchmarkOperatorResult
 
@@ -96,15 +96,13 @@ def _run(args: argparse.Namespace, extra_args: List[str]) -> BenchmarkOperatorRe
 def run(args: List[str] = []):
     if args == []:
         args = sys.argv[1:]
+    if config := os.environ.get("TRITONBENCH_RUN_CONFIG", None):
+        run_config(config)
+
     # Log the tool usage
     usage_report_logger(benchmark_name="tritonbench")
     parser = get_parser()
     args, extra_args = parser.parse_known_args(args)
-    if args.ci:
-        from .ci import run_ci  # @manual
-
-        run_ci()
-        return
 
     if args.op:
         ops = args.op.split(",")

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.gpu_utils import gpu_lockdown
 from tritonbench.utils.parser import get_parser
-from tritonbench.utils.run_utils import run_in_task, run_config
+from tritonbench.utils.run_utils import run_config, run_in_task
 
 from tritonbench.utils.triton_op import BenchmarkOperatorResult
 

--- a/run.py
+++ b/run.py
@@ -98,6 +98,7 @@ def run(args: List[str] = []):
         args = sys.argv[1:]
     if config := os.environ.get("TRITONBENCH_RUN_CONFIG", None):
         run_config(config)
+        return
 
     # Log the tool usage
     usage_report_logger(benchmark_name="tritonbench")

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -203,6 +203,11 @@ def get_parser(args=None):
         action="store_true",
         help="Only run with pre-defined production shapes.",
     )
+    parser.add_argument(
+        "--simple-output",
+        action="store_true",
+        help="Only print the simple output.",
+    )
 
     if is_fbcode():
         parser.add_argument(

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -4,12 +4,13 @@ import os
 import subprocess
 import sys
 import time
-import yaml
 
 from datetime import datetime
 from pathlib import Path
 
 from typing import Dict, List, Optional
+
+import yaml
 
 from tritonbench.utils.env_utils import is_fbcode
 from tritonbench.utils.git_utils import get_branch, get_commit_time, get_current_hash
@@ -85,6 +86,7 @@ def get_github_env() -> Dict[str, str]:
     out["RUNNER_OS"] = os.environ["RUNNER_OS"]
     return out
 
+
 def run_config(config_file: str):
     assert Path(config_file).exists(), f"Config file {config_file} must exist."
     with open(config_file, "r") as fp:
@@ -95,8 +97,11 @@ def run_config(config_file: str):
         benchmark_name = benchmark["benchmark_name"]
         run_in_task(op=None, op_args=op_args, benchmark_name=benchmark_name)
 
+
 def run_in_task(
-    op: Optional[str], op_args: Optional[List[str]] = None, benchmark_name: Optional[str] = None
+    op: Optional[str],
+    op_args: Optional[List[str]] = None,
+    benchmark_name: Optional[str] = None,
 ) -> None:
     op_task_cmd = [] if is_fbcode() else [sys.executable]
     if not op_args:
@@ -116,7 +121,7 @@ def run_in_task(
 
     # Remove "TRITONBENCH_RUN_CONFIG" env
     if "TRITONBENCH_RUN_CONFIG" in os.environ:
-         del os.environ["TRITONBENCH_RUN_CONFIG"]
+        del os.environ["TRITONBENCH_RUN_CONFIG"]
 
     # In OSS, we assume always using the run.py benchmark driver
     if not is_fbcode() and not op_task_cmd[1] == "run.py":

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+import yaml
 
 from datetime import datetime
 from pathlib import Path
@@ -84,9 +85,17 @@ def get_github_env() -> Dict[str, str]:
     out["RUNNER_OS"] = os.environ["RUNNER_OS"]
     return out
 
+def run_config(config_file: str):
+    assert Path(config_file).exists(), f"Config file {config_file} must exist."
+    with open(config_file, "r") as fp:
+        config = yaml.safe_load(fp)
+    benchmarks = config["benchmarks"].split(" ")
+    for benchmark in benchmarks:
+        benchmark_name = benchmark["benchmark_name"]
+        run_in_task(op=None, op_args=benchmark["args"], benchmark_name=benchmark_name)
 
 def run_in_task(
-    op: str, op_args: Optional[List[str]] = None, benchmark_name: Optional[str] = None
+    op: Optional[str], op_args: Optional[List[str]] = None, benchmark_name: Optional[str] = None
 ) -> None:
     op_task_cmd = [] if is_fbcode() else [sys.executable]
     if not op_args:

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -114,6 +114,10 @@ def run_in_task(
         else:
             benchmark_name = op
 
+    # Remove "TRITONBENCH_RUN_CONFIG" env
+    if "TRITONBENCH_RUN_CONFIG" in os.environ:
+         del os.environ["TRITONBENCH_RUN_CONFIG"]
+
     # In OSS, we assume always using the run.py benchmark driver
     if not is_fbcode() and not op_task_cmd[1] == "run.py":
         op_task_cmd.insert(1, "run.py")

--- a/tritonbench/utils/run_utils.py
+++ b/tritonbench/utils/run_utils.py
@@ -89,16 +89,18 @@ def run_config(config_file: str):
     assert Path(config_file).exists(), f"Config file {config_file} must exist."
     with open(config_file, "r") as fp:
         config = yaml.safe_load(fp)
-    benchmarks = config["benchmarks"].split(" ")
+    benchmarks = config["benchmarks"]
     for benchmark in benchmarks:
+        op_args = benchmark["args"].split(" ")
         benchmark_name = benchmark["benchmark_name"]
-        run_in_task(op=None, op_args=benchmark["args"], benchmark_name=benchmark_name)
+        run_in_task(op=None, op_args=op_args, benchmark_name=benchmark_name)
 
 def run_in_task(
     op: Optional[str], op_args: Optional[List[str]] = None, benchmark_name: Optional[str] = None
 ) -> None:
     op_task_cmd = [] if is_fbcode() else [sys.executable]
     if not op_args:
+        assert op, "If op_args is none, op must not be None."
         copy_sys_argv = copy.deepcopy(sys.argv)
         copy_sys_argv = remove_cmd_parameter(copy_sys_argv, "--op")
         copy_sys_argv = remove_cmd_parameter(copy_sys_argv, "--isolate")

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -266,6 +266,7 @@ class BenchmarkOperatorResult:
     op_name: str
     op_mode: str
     metrics: List[str]
+    simple_mode: bool
     # Tuple: (x_val, Dict[impl_name, BenchmarkOperatorMetrics])
     result: List[Tuple[Any, Dict[str, BenchmarkOperatorMetrics]]]
     _result_dict: Optional[Dict[Number, Dict[str, BenchmarkOperatorMetrics]]] = None
@@ -378,9 +379,18 @@ class BenchmarkOperatorResult:
                         )
                     col_num += 1
             table.append(row)
-        avg_row = ["average"] + [
-            x / len(self.result) if isinstance(x, Number) else None for x in avg_row
-        ]
+
+        if self.simple_mode:
+            # do not print header if in simple output mode
+            avg_row = [
+                str(x / len(self.result)) if isinstance(x, Number) else None
+                for x in avg_row
+            ]
+            avg_row = [",".join(avg_row)]
+        else:
+            avg_row = ["average"] + [
+                x / len(self.result) if isinstance(x, Number) else None for x in avg_row
+            ]
         table.append(avg_row)
         return headers, table
 
@@ -916,6 +926,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 op_name=self.name,
                 op_mode=self.mode.value,
                 metrics=self.required_metrics,
+                simple_mode=self.tb_args.simple_output,
                 result=metrics,
             )
 


### PR DESCRIPTION
Test plan:

```
TRITONBENCH_RUN_CONFIG=benchmarks/run_config/example_config.yaml python run.py
                               x_val    hstu-tflops
------------------------------------  -------------
(128, 4, 1024, 128, 128, 1.0, 20, 0)        201.411
                   201.4110902550313
```