### PR TITLE
Add TritonParse

### DIFF
--- a/install.py
+++ b/install.py
@@ -102,6 +102,12 @@ def install_liger():
     subprocess.check_call(cmd)
 
 
+def install_tritonparse():
+    # Install tritonparse from GitHub
+    cmd = ["pip", "install", "-e", "git+https://github.com/pytorch-labs/tritonparse.git#egg=tritonparse", "--no-deps"]
+    subprocess.check_call(cmd)
+
+
 def setup_hip(args: argparse.Namespace):
     # We have to disable all third-parties that donot support hip/rocm
     args.all = False
@@ -134,6 +140,7 @@ if __name__ == "__main__":
     parser.add_argument("--xformers", action="store_true", help="Install xformers")
     parser.add_argument("--tile", action="store_true", help="install tile lang")
     parser.add_argument("--aiter", action="store_true", help="install AMD's aiter")
+    parser.add_argument("--tritonparse", action="store_true", help="Install tritonparse")
     parser.add_argument(
         "--all", action="store_true", help="Install all custom kernel repos"
     )
@@ -193,4 +200,7 @@ if __name__ == "__main__":
         from tools.aiter.install import install_aiter
 
         install_aiter()
+    if args.tritonparse:
+        logger.info("[tritonbench] installing tritonparse...")
+        install_tritonparse()
     logger.info("[tritonbench] installation complete!")

--- a/install.py
+++ b/install.py
@@ -104,7 +104,13 @@ def install_liger():
 
 def install_tritonparse():
     # Install tritonparse from GitHub
-    cmd = ["pip", "install", "-e", "git+https://github.com/pytorch-labs/tritonparse.git#egg=tritonparse", "--no-deps"]
+    cmd = [
+        "pip",
+        "install",
+        "-e",
+        "git+https://github.com/pytorch-labs/tritonparse.git#egg=tritonparse",
+        "--no-deps",
+    ]
     subprocess.check_call(cmd)
 
 
@@ -140,7 +146,9 @@ if __name__ == "__main__":
     parser.add_argument("--xformers", action="store_true", help="Install xformers")
     parser.add_argument("--tile", action="store_true", help="install tile lang")
     parser.add_argument("--aiter", action="store_true", help="install AMD's aiter")
-    parser.add_argument("--tritonparse", action="store_true", help="Install tritonparse")
+    parser.add_argument(
+        "--tritonparse", action="store_true", help="Install tritonparse"
+    )
     parser.add_argument(
         "--all", action="store_true", help="Install all custom kernel repos"
     )

--- a/run.py
+++ b/run.py
@@ -105,6 +105,17 @@ def run(args: List[str] = []):
     parser = get_parser()
     args, extra_args = parser.parse_known_args(args)
 
+    # Initialize tritonparse if requested
+    if args.tritonparse is not None:
+        try:
+            import tritonparse.structured_logging
+            tritonparse.structured_logging.init(args.tritonparse)
+            print(f"[tritonbench] TritonParse structured logging initialized with log path: {args.tritonparse}")
+        except ImportError:
+            print("[tritonbench] Warning: tritonparse is not installed. Run 'python install.py --tritonparse' to install it.")
+        except Exception as e:
+            print(f"[tritonbench] Warning: Failed to initialize tritonparse: {e}")
+
     if args.op:
         ops = args.op.split(",")
     else:

--- a/run.py
+++ b/run.py
@@ -19,6 +19,7 @@ from tritonbench.utils.parser import get_parser
 from tritonbench.utils.run_utils import run_config, run_in_task
 
 from tritonbench.utils.triton_op import BenchmarkOperatorResult
+import importlib.util
 
 try:
     if is_fbcode():
@@ -108,13 +109,14 @@ def run(args: List[str] = []):
     # Initialize tritonparse if requested
     if args.tritonparse is not None:
         try:
+            if importlib.util.find_spec("tritonparse") is None:
+                print("Warning: tritonparse is not installed. Run 'python install.py --tritonparse' to install it.")
+                return
             import tritonparse.structured_logging
             tritonparse.structured_logging.init(args.tritonparse)
-            print(f"[tritonbench] TritonParse structured logging initialized with log path: {args.tritonparse}")
-        except ImportError:
-            print("[tritonbench] Warning: tritonparse is not installed. Run 'python install.py --tritonparse' to install it.")
+            print(f"TritonParse structured logging initialized with log path: {args.tritonparse}")
         except Exception as e:
-            print(f"[tritonbench] Warning: Failed to initialize tritonparse: {e}")
+            print(f"Warning: Failed to initialize tritonparse: {e}")
 
     if args.op:
         ops = args.op.split(",")

--- a/run.py
+++ b/run.py
@@ -110,11 +110,16 @@ def run(args: List[str] = []):
     if args.tritonparse is not None:
         try:
             if importlib.util.find_spec("tritonparse") is None:
-                print("Warning: tritonparse is not installed. Run 'python install.py --tritonparse' to install it.")
+                print(
+                    "Warning: tritonparse is not installed. Run 'python install.py --tritonparse' to install it."
+                )
                 return
             import tritonparse.structured_logging
+
             tritonparse.structured_logging.init(args.tritonparse)
-            print(f"TritonParse structured logging initialized with log path: {args.tritonparse}")
+            print(
+                f"TritonParse structured logging initialized with log path: {args.tritonparse}"
+            )
         except Exception as e:
             print(f"Warning: Failed to initialize tritonparse: {e}")
 

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -211,6 +211,14 @@ def get_parser(args=None):
         help="Only print the simple output.",
     )
 
+    parser.add_argument(
+        "--tritonparse",
+        nargs="?",
+        const="./tritonparse_logs/",
+        default=None,
+        help="Enable tritonparse structured logging. Optionally specify log directory path (default: ./tritonparse_logs/).",
+    )
+
     if is_fbcode():
         parser.add_argument(
             "--input-loader",


### PR DESCRIPTION
## Summary:
- Introduced a new function to install tritonparse from GitHub in install.py.
- Updated the argument parser to include --tritonparse option for installation.
- Added structured logging initialization for tritonparse in run.py, with error handling for import issues.
- Enhanced parser.py to support optional log directory specification for tritonparse.

This update allows users to easily install and utilize tritonparse for structured logging in their workflows.

## Test Plan:
Installation:
```bash
python install.py --tritonparse
```
Notice: 
This feature requires triton > 3.3.1 which is the latest release. You need to manually install triton for now.
Test:
```bash
python run.py --op addmm --num-inputs 1 --tritonparse
```
Alternatively, you can specify a custom directory using the `--tritonparse` option followed by the desired path (e.g., `--tritonparse ./logs`).

Then you can use https://pytorch-labs.github.io/tritonparse/ to open trace files to check triton compilation information. Check more details in https://github.com/pytorch-labs/tritonparse .