### PR TITLE
[CI] Support abtest benchmark

### DIFF
--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -51,11 +51,6 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-# BASE_CONDA_ENV and SETUP_SCRIPT must be set
-if [ -z "${BASE_CONDA_ENV}" ]; then
-  echo "ERROR: BASE_CONDA_ENV is not set"
-  exit 1
-fi
 if [ -z "${SETUP_SCRIPT}" ]; then
   echo "ERROR: SETUP_SCRIPT is not set"
   exit 1
@@ -87,8 +82,13 @@ CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
 conda activate "${BASE_CONDA_ENV}"
 # Remove the conda env if exists
 conda remove --name "${CONDA_ENV}" -y --all || true
-conda create --name "${CONDA_ENV}" -y --clone "${BASE_CONDA_ENV}"
+cd /workspace/tritonbench
+python tools/python_utils.py --create-conda-env "${CONDA_ENV}"
 conda activate "${CONDA_ENV}"
+RUN cd /workspace/tritonbench && \
+    . ${SETUP_SCRIPT} && \
+    python -m tools.cuda_utils --install-torch-deps && \
+    python -m tools.cuda_utils --install-torch-nightly
 
 . "${SETUP_SCRIPT}"
 

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -83,7 +83,7 @@ conda remove --name "${CONDA_ENV}" -y --all || true
 cd /workspace/tritonbench
 python tools/python_utils.py --create-conda-env "${CONDA_ENV}"
 conda activate "${CONDA_ENV}"
-RUN cd /workspace/tritonbench && \
+cd /workspace/tritonbench && \
     . ${SETUP_SCRIPT} && \
     python -m tools.cuda_utils --install-torch-deps && \
     python -m tools.cuda_utils --install-torch-nightly

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -81,12 +81,7 @@ CONDA_ENV=pytorch . "${SETUP_SCRIPT}"
 # Remove the conda env if exists
 conda remove --name "${CONDA_ENV}" -y --all || true
 cd /workspace/tritonbench
-python tools/python_utils.py --create-conda-env "${CONDA_ENV}"
-conda activate "${CONDA_ENV}"
-cd /workspace/tritonbench && \
-    . ${SETUP_SCRIPT} && \
-    python -m tools.cuda_utils --install-torch-deps && \
-    python -m tools.cuda_utils --install-torch-nightly
+conda create --name "${CONDA_ENV}" -y --clone pytorch
 
 . "${SETUP_SCRIPT}"
 

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -77,9 +77,7 @@ else
     exit 1
 fi
 
-# clone BASE_CONDA_ENV
-CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
-conda activate "${BASE_CONDA_ENV}"
+CONDA_ENV=pytorch . "${SETUP_SCRIPT}"
 # Remove the conda env if exists
 conda remove --name "${CONDA_ENV}" -y --all || true
 cd /workspace/tritonbench

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -75,7 +75,7 @@ if [ "${SIDE}" == "single" ]; then
     fi
 elif [ "${SIDE}" == "a" ] || [ "${SIDE}" == "b" ]; then
     mkdir -p /workspace/abtest
-    CONDA_ENV="triton_side_${SIDE}"
+    CONDA_ENV="triton-side-${SIDE}"
     TRITON_INSTALL_DIR=/workspace/abtest/${CONDA_ENV}
 else
     echo "Unknown side: ${SIDE}"

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -73,10 +73,10 @@ if [ "${SIDE}" == "single" ]; then
         echo "Must specifify CONDA_ENV if running with --side single."
         exit 1
     fi
-elif [ "${SIDE}" == "a" || "${SIDE}" == "b" ]; then
+elif [ "${SIDE}" == "a" ] || [ "${SIDE}" == "b" ]; then
     mkdir -p /workspace/abtest
-    TRITON_INSTALL_DIR=/workspace/abtest/${CONDA_ENV}
     CONDA_ENV="triton_side_${SIDE}"
+    TRITON_INSTALL_DIR=/workspace/abtest/${CONDA_ENV}
 else
     echo "Unknown side: ${SIDE}"
     exit 1

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+# Print usage
+usage() {
+    echo "Usage: $0 --repo <repo-path> --commit <commit-hash> --side <a|b|single>"
+    exit 1
+}
+
+# remove triton installations
+remove_triton() {
+    # delete the original triton directory
+    TRITON_PKG_DIR=$(python -c "import triton; import os; print(os.path.dirname(triton.__file__))")
+    # make sure all pytorch triton has been uninstalled
+    pip uninstall -y triton
+    pip uninstall -y triton
+    pip uninstall -y triton
+    rm -rf "${TRITON_PKG_DIR}"
+}
+
+checkout_triton() {
+    REPO=$1
+    COMMIT=$2
+    TRITON_INSTALL_DIR=$3
+    TRITON_INSTALL_DIRNAME=$(basename "${TRITON_INSTALL_DIR}")
+    TRITON_INSTALL_BASEDIR=$(dirname "${TRITON_INSTALL_DIR}")
+    cd "${TRITON_INSTALL_BASEDIR}"
+    git clone "https://github.com/${REPO}.git" "${TRITON_INSTALL_DIRNAME}"
+    cd "${TRITON_INSTALL_DIR}"
+    git checkout "${COMMIT}"
+}
+
+install_triton() {
+    TRITON_INSTALL_DIR=$1
+    cd "${TRITON_INSTALL_DIR}"
+    # install main triton
+    pip install ninja cmake wheel pybind11; # build-time dependencies
+    pip install -r python/requirements.txt
+    pip install -e .
+}
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --repo) REPO="$2"; shift ;;
+        --commit) COMMIT="$2"; shift ;;
+        --side) SIDE="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; usage ;;
+    esac
+    shift
+done
+
+# BASE_CONDA_ENV and SETUP_SCRIPT must be set
+if [ -z "${BASE_CONDA_ENV}" ]; then
+  echo "ERROR: BASE_CONDA_ENV is not set"
+  exit 1
+fi
+if [ -z "${SETUP_SCRIPT}" ]; then
+  echo "ERROR: SETUP_SCRIPT is not set"
+  exit 1
+fi
+
+# Validate arguments
+if [ -z "${REPO}" ] || [ -z "${COMMIT}" ] || [ -z "${SIDE}" ]; then
+    echo "Missing required arguments."
+    usage
+fi
+
+# clone BASE_CONDA_ENV
+CONDA_ENV=${BASE_CONDA_ENV} . "${SETUP_SCRIPT}"
+conda activate "${BASE_CONDA_ENV}"
+# Remove the conda env if exists
+conda remove --name "${CONDA_ENV}" -y --all || true
+conda create --name "${CONDA_ENV}" -y --clone "${BASE_CONDA_ENV}"
+conda activate "${CONDA_ENV}"
+
+. "${SETUP_SCRIPT}"
+
+remove_triton
+
+# checkout triton to /workspace/abtest/<env-name> and install it
+if [ "${SIDE}" == "single" ]; then
+    TRITON_INSTALL_DIR=/workspace/triton
+elif [ "${SIDE}" == "a" ]; then
+    TRITON_INSTALL_DIR=/workspace/abtest/triton_a
+elif [ "${SIDE}" == "b" ]; then
+    TRITON_INSTALL_DIR=/workspace/abtest/triton_b
+else
+    echo "Unknown side: ${SIDE}"
+    exit 1
+fi
+
+checkout_triton "${REPO}" "${COMMIT}" "${TRITON_INSTALL_DIR}"
+install_triton "${TRITON_INSTALL_DIR}"
+
+SIDE_UPPER="${SIDE^^}"
+
+# export Triton repo related envs
+# these envs will be used in nightly runs and other benchmarks
+cd "${TRITON_INSTALL_DIR}"
+TRITONBENCH_TRITON_COMMIT=$(git rev-parse --verify HEAD)
+echo "export TRITONBENCH_TRITON_COMMIT=${TRITONBENCH_TRITON_COMMIT}" >> /workspace/setup_instance.sh
+echo "export TRITONBENCH_TRITON_REPO=${TRITON_INSTALL_DIR}" >> /workspace/setup_instance.sh

--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -103,4 +103,4 @@ cd "${TRITON_INSTALL_DIR}"
 TRITONBENCH_TRITON_COMMIT=$(git rev-parse --verify HEAD)
 TRITONBENCH_TRITON_REPO=$(git config --get remote.origin.url | sed -E 's|.*github.com[:/](.+)\.git|\1|')
 echo "export TRITONBENCH_TRITON_COMMIT=${TRITONBENCH_TRITON_COMMIT}" >> /workspace/setup_instance.sh
-echo "export TRITONBENCH_TRITON_REPO=${TRITON_INSTALL_DIR}" >> /workspace/setup_instance.sh
+echo "export TRITONBENCH_TRITON_REPO=${TRITONBENCH_TRITON_REPO}" >> /workspace/setup_instance.sh

--- a/.ci/tritonbench/run-benchmark.sh
+++ b/.ci/tritonbench/run-benchmark.sh
@@ -11,11 +11,22 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-. "${SETUP_SCRIPT}"
-
 BENCHMARK_NAME=$1
+shift
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --conda-env) CONDA_ENV="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; usage ;;
+    esac
+    shift
+done
 
 tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
 cd "${tritonbench_dir}"
 
+echo "Running ${BENCHMARK_NAME} benchmark under conda env ${CONDA_ENV}"
+
+. "${SETUP_SCRIPT}"
 python "benchmarks/${BENCHMARK_NAME}/run.py" --ci

--- a/.ci/tritonbench/run-benchmark.sh
+++ b/.ci/tritonbench/run-benchmark.sh
@@ -23,6 +23,11 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+if [ -z "${CONDA_ENV}" ]; then
+  echo "ERROR: CONDA_ENV is not set"
+  exit 1
+fi
+
 tritonbench_dir=$(dirname "$(readlink -f "$0")")/../..
 cd "${tritonbench_dir}"
 

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -17,6 +17,27 @@ on:
         type: string
         description: |
           Conda environment to activate when testing Triton
+      test_type:
+        required: True
+        type: string
+        description: |
+          Test type, e.g., "periodic" or "ab_test"
+      side_a_triton:
+        type: string
+        description: |
+          Triton repository to test on side A, e.g., "triton-lang/triton"
+      side_a_commit:
+        type: string
+        description: |
+          Triton commit or tag to test on side A, e.g., "main"
+      side_b_triton:
+        type: string
+        description: |
+          Triton repository to test on side B, e.g., "triton-lang/triton"
+      side_b_commit:
+        type: string
+        description: |
+          Triton commit or tag to test on side B, e.g., "main"
 
 jobs:
   linux-benchmark-h100:
@@ -52,7 +73,26 @@ jobs:
           # The max duration enforced by the server side
           role-duration-seconds: 18000
           aws-region: us-east-1
+      - name: Compile Triton (Side A)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+      - name: Benchmark Triton (Side A)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
+      - name: Compile Triton (Side B)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+      - name: Benchmark Triton (Side B)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-b
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-b
       - name: Benchmarking periodic
+        if: ${{ inputs.test_type == 'periodic' }}
         run: |
           bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
@@ -64,13 +104,13 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          result_json=$(find ./benchmark-output -name "result.json"  | sort -r | tail -n 1)
-          python ./.ci/upload/scribe.py --json ${result_json}
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          python ./.ci/upload/scribe.py --json ${result_jsons}
       - name: Rewrite Tritonbench json to ClickHouse style
         run: |
           . "${SETUP_SCRIPT}"
-          result_json=$(find ./benchmark-output -name "result.json"  | sort -r | tail -n 1)
-          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_json} \
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_jsons} \
                  --output-dir benchmark-output/results
       - name: Setup uploader dependencies
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -115,6 +115,11 @@ jobs:
           dry-run: false
           schema-version: v3
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf ./.benchmarks || true
+          rm -rf benchmark-output || true
       - name: Restore Nvidia GPU
         if: always()
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       RUNNER_TYPE: "gcp-h100-runner"
-      JOB_NAME: tritonbench-h100-abtest-${{ inputs.side_a_triton }}-${{ inputs.side_a_commit }}-${{ inputs.side_b_triton }}-${{ inputs.side_b_commit }}-${{ inputs.benchmark_name }}
+      JOB_NAME: tritonbench-h100-abtest-${{ inputs.benchmark_name }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -87,7 +87,7 @@ jobs:
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tritonbench-abtest-output
+          name: ${{ env.JOB_NAME }}
           path: benchmark-output/
       - name: Upload result to Scribe
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -47,6 +47,7 @@ jobs:
     env:
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       RUNNER_TYPE: "gcp-h100-runner"
+      BASE_CONDA_ENV: "pytorch"
       JOB_NAME: tritonbench-h100-abtest-${{ inputs.side_a_triton }}-${{ inputs.side_a_commit }}-${{ inputs.side_b_triton }}-${{ inputs.side_b_commit }}-${{ inputs.benchmark_name }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Benchmark Triton (Side A)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-a
+          mkdir -p benchmark-output
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
       - name: Compile Triton (Side B)
         run: |
@@ -81,6 +82,7 @@ jobs:
       - name: Benchmark Triton (Side B)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-b
+          mkdir -p benchmark-output
           cp -r ".benchmarks/${{ inputs.benchmark_name }}" benchmark-output/triton-side-b
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -17,25 +17,26 @@ on:
         type: string
         description: |
           Conda environment to activate when testing Triton
-      test_type:
-        required: True
-        type: string
-        description: |
-          Test type, e.g., "periodic" or "ab_test"
       side_a_triton:
         type: string
+        required: True
+        default: "triton-lang/triton"
         description: |
           Triton repository to test on side A, e.g., "triton-lang/triton"
       side_a_commit:
         type: string
+        required: True
         description: |
           Triton commit or tag to test on side A, e.g., "main"
       side_b_triton:
         type: string
+        required: True
+        default: "triton-lang/triton"
         description: |
           Triton repository to test on side B, e.g., "triton-lang/triton"
       side_b_commit:
         type: string
+        required: True
         description: |
           Triton commit or tag to test on side B, e.g., "main"
 
@@ -74,28 +75,19 @@ jobs:
           role-duration-seconds: 18000
           aws-region: us-east-1
       - name: Compile Triton (Side A)
-        if: ${{ inputs.test_type == 'ab_test' }}
         run: |
-          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-b
       - name: Benchmark Triton (Side A)
-        if: ${{ inputs.test_type == 'ab_test' }}
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
       - name: Compile Triton (Side B)
-        if: ${{ inputs.test_type == 'ab_test' }}
         run: |
-          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-b
       - name: Benchmark Triton (Side B)
-        if: ${{ inputs.test_type == 'ab_test' }}
         run: |
-          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-b
-          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-b
-      - name: Benchmarking periodic
-        if: ${{ inputs.test_type == 'periodic' }}
-        run: |
-          bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
-          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
+          bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-b
+          cp -r ".benchmarks/${{ inputs.benchmark_name }}" benchmark-output/triton-side-b
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -104,14 +96,19 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
-          python ./.ci/upload/scribe.py --json ${result_jsons}
+          triton_side_a_json=$(find ./benchmark-output/triton-side-a -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/upload/scribe.py --json ${triton_side_a_json}
+          triton_side_b_json=$(find ./benchmark-output/triton-side-b -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/upload/scribe.py --json ${triton_side_b_json}
       - name: Rewrite Tritonbench json to ClickHouse style
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
-          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_jsons} \
-                 --output-dir benchmark-output/results
+          triton_side_a_json=$(find ./benchmark-output/triton-side-a -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json "${triton_side_a_json}" \
+                 --output benchmark-output/results/triton-side-a.json
+          triton_side_b_json=$(find ./benchmark-output/triton-side-b -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json "${triton_side_b_json}" \
+                 --output benchmark-output/results/triton-side-b.json
       - name: Setup uploader dependencies
         run: |
           sudo apt-get install -y python3-pip

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -76,6 +76,7 @@ jobs:
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-a
           mkdir -p benchmark-output
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
+          rm -rf .benchmarks || true
       - name: Compile Triton (Side B)
         run: |
           bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --side b
@@ -84,6 +85,7 @@ jobs:
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-b
           mkdir -p benchmark-output
           cp -r ".benchmarks/${{ inputs.benchmark_name }}" benchmark-output/triton-side-b
+          rm -rf .benchmarks || true
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -115,11 +117,6 @@ jobs:
           dry-run: false
           schema-version: v3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cleanup
-        if: always()
-        run: |
-          rm -rf ./.benchmarks || true
-          rm -rf benchmark-output || true
       - name: Restore Nvidia GPU
         if: always()
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -47,7 +47,6 @@ jobs:
     env:
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
       RUNNER_TYPE: "gcp-h100-runner"
-      BASE_CONDA_ENV: "pytorch"
       JOB_NAME: tritonbench-h100-abtest-${{ inputs.side_a_triton }}-${{ inputs.side_a_commit }}-${{ inputs.side_b_triton }}-${{ inputs.side_b_commit }}-${{ inputs.benchmark_name }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -1,0 +1,90 @@
+name: linux-benchmark-h100
+on:
+  workflow_call:
+    secrets:
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN:
+        required: True
+        description: |
+          Tritonbench Scribe Graph Access Token
+    inputs:
+      benchmark_name:
+        required: True
+        type: string
+        description: |
+          Benchmark name
+      conda_env:
+        required: True
+        type: string
+        description: |
+          Conda environment to activate when testing Triton
+
+jobs:
+  linux-benchmark-h100:
+    if: github.repository_owner == 'pytorch-labs'
+    runs-on: [gcp-h100-runner]
+    timeout-minutes: 240
+    environment: docker-s3-upload
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      SETUP_SCRIPT: "/workspace/setup_instance.sh"
+      CONDA_ENV: ${{ inputs.conda_env }}
+      RUNNER_TYPE: "gcp-h100-runner"
+      JOB_NAME: tritonbench-h100-${{ inputs.conda_env }}-${{ inputs.benchmark_name }}
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Checkout Tritonbench
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Tune Nvidia GPU
+        run: |
+          bash .ci/gpu/tune-gcp-h100.sh
+          sudo ldconfig
+          nvidia-smi
+      - name: Authenticate with AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results
+          # The max duration enforced by the server side
+          role-duration-seconds: 18000
+          aws-region: us-east-1
+      - name: Benchmarking periodic
+        run: |
+          bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
+      - name: Upload result to GH Actions Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.JOB_NAME }}
+          path: benchmark-output/
+      - name: Upload result to Scribe
+        run: |
+          . "${SETUP_SCRIPT}"
+          result_json=$(find ./benchmark-output -name "result.json"  | sort -r | tail -n 1)
+          python ./.ci/upload/scribe.py --json ${result_json}
+      - name: Rewrite Tritonbench json to ClickHouse style
+        run: |
+          . "${SETUP_SCRIPT}"
+          result_json=$(find ./benchmark-output -name "result.json"  | sort -r | tail -n 1)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_json} \
+                 --output-dir benchmark-output/results
+      - name: Setup uploader dependencies
+        run: |
+          sudo apt-get install -y python3-pip
+      - name: Upload result to ClickHouse
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        with:
+          benchmark-results-dir: benchmark-output/results
+          dry-run: false
+          schema-version: v3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore Nvidia GPU
+        if: always()
+        run: |
+          bash .ci/gpu/reset-gcp-h100.sh
+          sudo ldconfig
+          nvidia-smi

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.JOB_NAME }}
+          name: tritonbench-abtest-output
           path: benchmark-output/
       - name: Upload result to Scribe
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -74,7 +74,7 @@ jobs:
           bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --side a
       - name: Benchmark Triton (Side A)
         run: |
-          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
+          bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-a
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
       - name: Compile Triton (Side B)
         run: |

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -70,14 +70,14 @@ jobs:
           aws-region: us-east-1
       - name: Compile Triton (Side A)
         run: |
-          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-a
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --side a
       - name: Benchmark Triton (Side A)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
       - name: Compile Triton (Side B)
         run: |
-          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --side b
       - name: Benchmark Triton (Side B)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-b

--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -12,11 +12,6 @@ on:
         type: string
         description: |
           Benchmark name
-      conda_env:
-        required: True
-        type: string
-        description: |
-          Conda environment to activate when testing Triton
       side_a_triton:
         type: string
         required: True
@@ -51,9 +46,8 @@ jobs:
       contents: read
     env:
       SETUP_SCRIPT: "/workspace/setup_instance.sh"
-      CONDA_ENV: ${{ inputs.conda_env }}
       RUNNER_TYPE: "gcp-h100-runner"
-      JOB_NAME: tritonbench-h100-${{ inputs.conda_env }}-${{ inputs.benchmark_name }}
+      JOB_NAME: tritonbench-h100-abtest-${{ inputs.side_a_triton }}-${{ inputs.side_a_commit }}-${{ inputs.side_b_triton }}-${{ inputs.side_b_commit }}-${{ inputs.benchmark_name }}
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -76,7 +70,7 @@ jobs:
           aws-region: us-east-1
       - name: Compile Triton (Side A)
         run: |
-          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --conda-env triton-side-a
       - name: Benchmark Triton (Side A)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -71,7 +71,7 @@ jobs:
           . "${SETUP_SCRIPT}"
           latest_result_json=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
           python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${latest_result_json} \
-                 --output-dir benchmark-output/results
+                 --output benchmark-output/results/result.json
       - name: Setup uploader dependencies
         run: |
           sudo apt-get install -y python3-pip

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -17,27 +17,6 @@ on:
         type: string
         description: |
           Conda environment to activate when testing Triton
-      test_type:
-        required: True
-        type: string
-        description: |
-          Test type, e.g., "periodic" or "ab_test"
-      side_a_triton:
-        type: string
-        description: |
-          Triton repository to test on side A, e.g., "triton-lang/triton"
-      side_a_commit:
-        type: string
-        description: |
-          Triton commit or tag to test on side A, e.g., "main"
-      side_b_triton:
-        type: string
-        description: |
-          Triton repository to test on side B, e.g., "triton-lang/triton"
-      side_b_commit:
-        type: string
-        description: |
-          Triton commit or tag to test on side B, e.g., "main"
 
 jobs:
   linux-benchmark-h100:
@@ -73,29 +52,10 @@ jobs:
           # The max duration enforced by the server side
           role-duration-seconds: 18000
           aws-region: us-east-1
-      - name: Compile Triton (Side A)
-        if: ${{ inputs.test_type == 'ab_test' }}
-        run: |
-          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
-      - name: Benchmark Triton (Side A)
-        if: ${{ inputs.test_type == 'ab_test' }}
-        run: |
-          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
-          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
-      - name: Compile Triton (Side B)
-        if: ${{ inputs.test_type == 'ab_test' }}
-        run: |
-          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
-      - name: Benchmark Triton (Side B)
-        if: ${{ inputs.test_type == 'ab_test' }}
-        run: |
-          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-b
-          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-b
-      - name: Benchmarking periodic
-        if: ${{ inputs.test_type == 'periodic' }}
+      - name: Benchmarking
         run: |
           bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
-          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
+          cp -r ".benchmarks/${{ inputs.benchmark_name }}" benchmark-output
       - name: Upload result to GH Actions Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -104,12 +64,12 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
           python ./.ci/upload/scribe.py --json ${result_jsons}
       - name: Rewrite Tritonbench json to ClickHouse style
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
           python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_jsons} \
                  --output-dir benchmark-output/results
       - name: Setup uploader dependencies

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Compile Triton (Side A)
         if: ${{ inputs.test_type == 'ab_test' }}
         run: |
-          bash ./.ci/tritonbench/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
       - name: Benchmark Triton (Side A)
         if: ${{ inputs.test_type == 'ab_test' }}
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Compile Triton (Side B)
         if: ${{ inputs.test_type == 'ab_test' }}
         run: |
-          bash ./.ci/tritonbench/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+          bash ./.ci/triton/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
       - name: Benchmark Triton (Side B)
         if: ${{ inputs.test_type == 'ab_test' }}
         run: |

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -17,6 +17,27 @@ on:
         type: string
         description: |
           Conda environment to activate when testing Triton
+      test_type:
+        required: True
+        type: string
+        description: |
+          Test type, e.g., "periodic" or "ab_test"
+      side_a_triton:
+        type: string
+        description: |
+          Triton repository to test on side A, e.g., "triton-lang/triton"
+      side_a_commit:
+        type: string
+        description: |
+          Triton commit or tag to test on side A, e.g., "main"
+      side_b_triton:
+        type: string
+        description: |
+          Triton repository to test on side B, e.g., "triton-lang/triton"
+      side_b_commit:
+        type: string
+        description: |
+          Triton commit or tag to test on side B, e.g., "main"
 
 jobs:
   linux-benchmark-h100:
@@ -52,7 +73,26 @@ jobs:
           # The max duration enforced by the server side
           role-duration-seconds: 18000
           aws-region: us-east-1
-      - name: Benchmarking
+      - name: Compile Triton (Side A)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+      - name: Benchmark Triton (Side A)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-a
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-a
+      - name: Compile Triton (Side B)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/compile.sh ${{ inputs.side_a_triton }} ${{ inputs.side_a_commit }} --conda-env triton-side-b
+      - name: Benchmark Triton (Side B)
+        if: ${{ inputs.test_type == 'ab_test' }}
+        run: |
+          bash ./.ci/tritonbench/run-benchmark.sh --conda-env triton-side-b
+          cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output/triton-side-b
+      - name: Benchmarking periodic
+        if: ${{ inputs.test_type == 'periodic' }}
         run: |
           bash .ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }}
           cp -r .benchmarks/${{ inputs.benchmark_name }} benchmark-output
@@ -64,14 +104,14 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          latest_result_json=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
-          python ./.ci/upload/scribe.py --json ${latest_result_json}
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          python ./.ci/upload/scribe.py --json ${result_jsons}
       - name: Rewrite Tritonbench json to ClickHouse style
         run: |
           . "${SETUP_SCRIPT}"
-          latest_result_json=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
-          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${latest_result_json} \
-                 --output benchmark-output/results/result.json
+          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_jsons} \
+                 --output-dir benchmark-output/results
       - name: Setup uploader dependencies
         run: |
           sudo apt-get install -y python3-pip

--- a/.github/workflows/_linux-benchmark-h100.yml
+++ b/.github/workflows/_linux-benchmark-h100.yml
@@ -64,13 +64,13 @@ jobs:
       - name: Upload result to Scribe
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
-          python ./.ci/upload/scribe.py --json ${result_jsons}
+          latest_result_json=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/upload/scribe.py --json ${latest_result_json}
       - name: Rewrite Tritonbench json to ClickHouse style
         run: |
           . "${SETUP_SCRIPT}"
-          result_jsons=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
-          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${result_jsons} \
+          latest_result_json=$(find ./benchmark-output -name "result.json"  | sort -r | head -n 1)
+          python ./.ci/test_infra/oss_ci_benchmark_v3.py --json ${latest_result_json} \
                  --output-dir benchmark-output/results
       - name: Setup uploader dependencies
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ on:
       - .github/workflows/nightly.yml
 
 jobs:
-  h100-triton-nightly-periodic-test:
+  h100-triton-main-nightly-periodic-test:
     uses: ./.github/workflows/_linux-benchmark-h100.yml
     if: ${{ inputs.test_type == 'periodic' }}
     with:
@@ -40,7 +40,7 @@ jobs:
       benchmark_name: "nightly"
     secrets:
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-  h100-triton-nightly-ab-test:
+  h100-triton-nightly-abtest:
     uses: ./.github/workflows/_linux-benchmark-abtest-h100.yml
     if: ${{ inputs.test_type == 'ab_test' }}
     with:
@@ -50,7 +50,7 @@ jobs:
       side_b_triton: ${{ inputs.side_b_triton }}
       side_b_triton_commit: ${{ inputs.side_b_triton_commit }}
     secrets:
-      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPH
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPH }}
 
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ on:
       - .github/workflows/nightly.yml
 
 jobs:
-  h100-triton-main-nightly-periodic-test:
+  h100-triton-main-nightly-periodic:
     uses: ./.github/workflows/_linux-benchmark-h100.yml
     if: ${{ inputs.test_type == 'periodic' }}
     with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,18 +32,25 @@ on:
       - .github/workflows/nightly.yml
 
 jobs:
-  h100-triton-main-nightly-test:
+  h100-triton-nightly-periodic-test:
     uses: ./.github/workflows/_linux-benchmark-h100.yml
+    if: ${{ inputs.test_type == 'periodic' }}
     with:
       conda_env: "triton-main"
       benchmark_name: "nightly"
-      test_type: ${{ inputs.test_type }}
+    secrets:
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+  h100-triton-nightly-ab-test:
+    uses: ./.github/workflows/_linux-benchmark-abtest-h100.yml
+    if: ${{ inputs.test_type == 'ab_test' }}
+    with:
+      benchmark_name: "nightly"
       side_a_triton: ${{ inputs.side_a_triton }}
       side_a_triton_commit: ${{ inputs.side_a_triton_commit }}
       side_b_triton: ${{ inputs.side_b_triton }}
       side_b_triton_commit: ${{ inputs.side_b_triton_commit }}
     secrets:
-      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPH
 
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
       side_b_triton: ${{ inputs.side_b_triton }}
       side_b_commit: ${{ inputs.side_b_commit }}
     secrets:
-      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPH }}
+      TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
 
 
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,9 +9,9 @@ on:
         type: choice
         required: true
         description: 'Choose advanced testing options'
-        default: 'periodic'
+        default: 'single'
         options:
-          - 'periodic'
+          - 'single'
           - 'abtest'
       side_a_triton:
         default: 'triton-lang/triton'
@@ -34,7 +34,7 @@ on:
 jobs:
   h100-triton-main-nightly-periodic:
     uses: ./.github/workflows/_linux-benchmark-h100.yml
-    if: ${{ inputs.test_type == 'periodic' }}
+    if: ${{ inputs.test_type != 'abtest' }}
     with:
       conda_env: "triton-main"
       benchmark_name: "nightly"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,13 +16,13 @@ on:
       side_a_triton:
         default: 'triton-lang/triton'
         description: 'Side A Triton repo'
-      side_a_triton_commit:
+      side_a_commit:
         default: 'main'
         description: 'Side A Triton commit'
       side_b_triton:
         default: 'triton-lang/triton'
         description: 'Side B Triton repo'
-      side_b_triton_commit:
+      side_b_commit:
         default: 'main'
         description: 'Side B Triton commit'
   pull_request:
@@ -46,9 +46,9 @@ jobs:
     with:
       benchmark_name: "nightly"
       side_a_triton: ${{ inputs.side_a_triton }}
-      side_a_triton_commit: ${{ inputs.side_a_triton_commit }}
+      side_a_commit: ${{ inputs.side_a_commit }}
       side_b_triton: ${{ inputs.side_b_triton }}
-      side_b_triton_commit: ${{ inputs.side_b_triton_commit }}
+      side_b_commit: ${{ inputs.side_b_commit }}
     secrets:
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPH }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,27 @@ on:
     # Test nightly docker daily at 4 PM UTC
     - cron: '0 16 * * *'
   workflow_dispatch:
+    inputs:
+      test_type:
+        type: choice
+        required: true
+        description: 'Choose advanced testing options'
+        default: 'periodic'
+        options:
+          - 'periodic'
+          - 'ab_test'
+      side_a_triton:
+        default: 'triton-lang/triton'
+        description: 'Side A Triton repo'
+      side_a_triton_commit:
+        default: 'main'
+        description: 'Side A Triton commit'
+      side_b_triton:
+        default: 'triton-lang/triton'
+        description: 'Side B Triton repo'
+      side_b_triton_commit:
+        default: 'main'
+        description: 'Side B Triton commit'
   pull_request:
     paths:
       - benchmarks/nightly/**
@@ -16,6 +37,11 @@ jobs:
     with:
       conda_env: "triton-main"
       benchmark_name: "nightly"
+      test_type: ${{ inputs.test_type }}
+      side_a_triton: ${{ inputs.side_a_triton }}
+      side_a_triton_commit: ${{ inputs.side_a_triton_commit }}
+      side_b_triton: ${{ inputs.side_b_triton }}
+      side_b_triton_commit: ${{ inputs.side_b_triton_commit }}
     secrets:
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ on:
         default: 'periodic'
         options:
           - 'periodic'
-          - 'ab_test'
+          - 'abtest'
       side_a_triton:
         default: 'triton-lang/triton'
         description: 'Side A Triton repo'
@@ -42,7 +42,7 @@ jobs:
       TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.TRITONBENCH_SCRIBE_GRAPHQL_ACCESS_TOKEN }}
   h100-triton-nightly-abtest:
     uses: ./.github/workflows/_linux-benchmark-abtest-h100.yml
-    if: ${{ inputs.test_type == 'ab_test' }}
+    if: ${{ inputs.test_type == 'abtest' }}
     with:
       benchmark_name: "nightly"
       side_a_triton: ${{ inputs.side_a_triton }}


### PR DESCRIPTION
For any benchmarks in `benchmarks/` directory, we now support running abtest on two Triton versions.

Test plan:
https://github.com/pytorch-labs/tritonbench/actions/runs/15781464225