### PR TITLE
Fix OSS breakage with global variables access

### DIFF
--- a/tritonbench/kernels/profile.py
+++ b/tritonbench/kernels/profile.py
@@ -8,8 +8,8 @@ import triton.language as tl
 from tritonbench.utils.env_utils import is_cuda, is_hip
 
 
-IS_CUDA: tl.constexpr = is_cuda()
-IS_HIP: tl.constexpr = is_hip()
+IS_CUDA = tl.constexpr(is_cuda())
+IS_HIP = tl.constexpr(is_hip())
 
 
 @triton.jit


### PR DESCRIPTION
Summary:
The upstream triton had a breaking change that requires global variables to be instantiated as constexpr: https://github.com/triton-lang/triton/pull/5961

In other words, in following is no longer supported:
```
x: triton.language.constexpr = 42
```
And should be changed to:
```
x = triton.language.constexpr(42)
```

Not sure about the motivation of this change, but this PR fixes the issue of breaking OSS CI (e.g., https://github.com/pytorch-labs/tritonbench/actions/runs/15741774545/job/44368618858)

Reviewed By: xuzhao9

Differential Revision: D76931030
