### PR TITLE
Update ragged_attention_bwd to autotune on each max_seq_len

### DIFF
--- a/tritonbench/operators/ragged_attention/hstu.py
+++ b/tritonbench/operators/ragged_attention/hstu.py
@@ -6,7 +6,11 @@ from tritonbench.utils.path_utils import add_path, SUBMODULE_PATH
 
 if is_fbcode():
     # Internal Imports
-    from generative_recommenders.common import apply_sampling, generate_sparse_seq_len
+    from generative_recommenders.common import (
+        apply_sampling,
+        generate_sparse_seq_len,
+        set_use_runtime_max_seq_len,
+    )
     from generative_recommenders.ops.triton.triton_hstu_attention import triton_hstu_mha
 else:
     # OSS Import
@@ -14,6 +18,7 @@ else:
         from generative_recommenders.common import (
             apply_sampling,
             generate_sparse_seq_len,
+            set_use_runtime_max_seq_len,
         )
         from generative_recommenders.ops.triton.triton_hstu_attention import (
             triton_hstu_mha,
@@ -22,6 +27,9 @@ else:
 from typing import Tuple
 
 triton_hstu_mha = triton_hstu_mha
+
+# Always autotune based on the actual max_seq_len
+set_use_runtime_max_seq_len(True)
 
 
 def get_test_inputs(


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-recsys/generative-recommenders/pull/300

ragged_attention_bwd won't autotune for each shape unless you set `set_use_runtime_max_seq_len(True)`. This causes a regression with the update because there is no a larger difference between the optimal configs fore each shape.

Also given the changes in the update I added an extra config because that can reach a higher performance for the last shape.

Differential Revision: D77260389


