### PR TITLE
[ci][nightly] Enable more tests

### DIFF
--- a/benchmarks/nightly/autogen.yaml
+++ b/benchmarks/nightly/autogen.yaml
@@ -8,31 +8,28 @@ cross_entropy_fwd:
 embedding_fwd:
   op: embedding
   args: --op embedding --baseline torch_embedding --metrics speedup --only liger_embedding,torch_embedding
-# TODO: fix in the CI
-# bf16_flash_attention_fwd:
-#   op: flash_attention
-#   args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --only triton_tutorial_flash_v2,triton_tutorial_flash_v2_opt,flash_v3
+bf16_flash_attention_fwd:
+  op: flash_attention
+  args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --only triton_tutorial_flash_v2,flash_v3
 bf16_flex_attention_fwd:
   op: flex_attention
   args: --op flex_attention --baseline eager --metrics tflops,speedup --only compiled,eager
-# TODO: fix in the CI
-# fp8_gemm_fwd:
-#   op: fp8_gemm
-#   args: --op fp8_gemm --baseline torch_fp8_gemm --metrics tflops,speedup --only triton_tma_persistent_fp8_gemm,torch_fp8_gemm
+bf16_ragged_attention_fwd:
+  op: ragged_attention
+  args: --op ragged_attention --metrics tflops --only hstu
+fp8_gemm_fwd:
+  op: fp8_gemm
+  args: --op fp8_gemm --baseline torch_fp8_gemm --metrics tflops,speedup --only triton_tma_persistent_fp8_gemm,torch_fp8_gemm
 fp8_gemm_blockwise_fwd:
   op: fp8_gemm_blockwise
   args: --op fp8_gemm_blockwise --baseline _cutlass --metrics tflops,speedup --only
     _triton,_cutlass
-# TODO: fix in the CI
-# fp8_gemm_rowwise_fwd:
-#   op: fp8_gemm_rowwise
-#   args: --op fp8_gemm_rowwise --baseline _cutlass_or_ck --metrics tflops,speedup --only
-#     _triton,_cutlass_or_ck
-# TODO: fix in the CI
-# fp8_gemm_rowwise_grouped_fwd:
-#   op: fp8_gemm_rowwise_grouped
-#   args: --op fp8_gemm_rowwise_grouped --baseline _cutlass_or_ck --metrics tflops,speedup
-#     --only _triton,_cutlass_or_ck
+fp8_gemm_rowwise_fwd:
+  op: fp8_gemm_rowwise
+  args: --op fp8_gemm_rowwise --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
+fp8_gemm_rowwise_grouped_fwd:
+  op: fp8_gemm_rowwise_grouped
+  args: --op fp8_gemm_rowwise_grouped --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
 fused_linear_cross_entropy_fwd:
   op: fused_linear_cross_entropy
   args: --op fused_linear_cross_entropy --baseline torch_lm_head_ce --metrics speedup
@@ -88,11 +85,9 @@ cross_entropy_bwd:
 embedding_bwd:
   op: embedding
   args: --op embedding --baseline torch_embedding --metrics speedup --bwd --only liger_embedding,torch_embedding,torch_embedding
-# TODO: Fix in the CI
-# bf16_flash_attention_bwd:
-#   op: flash_attention
-#   args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --bwd --only
-#     triton_tutorial_flash_v2,triton_tutorial_flash_v2_opt,flash_v3,flash_v3
+bf16_flash_attention_bwd:
+  op: flash_attention
+  args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --bwd --only triton_tutorial_flash_v2,flash_v3
 bf16_flex_attention_bwd:
   op: flex_attention
   args: --op flex_attention --baseline eager --metrics tflops,speedup --bwd --only

--- a/benchmarks/nightly/autogen.yaml
+++ b/benchmarks/nightly/autogen.yaml
@@ -84,10 +84,10 @@ welford_fwd:
 cross_entropy_bwd:
   op: cross_entropy
   args: --op cross_entropy --baseline cross_entropy_loss --metrics speedup --bwd --only
-    liger_cross_entropy_loss,cross_entropy_loss,cross_entropy_loss
+    liger_cross_entropy_loss,cross_entropy_loss
 embedding_bwd:
   op: embedding
-  args: --op embedding --baseline torch_embedding --metrics speedup --bwd --only liger_embedding,torch_embedding,torch_embedding
+  args: --op embedding --baseline torch_embedding --metrics speedup --bwd --only liger_embedding,torch_embedding
 # flash_attention triton bwd only works with causal
 bf16_flash_attention_bwd:
   op: flash_attention
@@ -95,24 +95,24 @@ bf16_flash_attention_bwd:
 bf16_flex_attention_bwd:
   op: flex_attention
   args: --op flex_attention --baseline eager --metrics tflops,speedup --bwd --only
-    compiled,eager,eager
+    compiled,eager
 fused_linear_cross_entropy_bwd:
   op: fused_linear_cross_entropy
   args: --op fused_linear_cross_entropy --baseline torch_lm_head_ce --metrics speedup
-    --bwd --only liger_lm_head_ce,torch_lm_head_ce,torch_lm_head_ce
+    --bwd --only liger_lm_head_ce,torch_lm_head_ce
 fused_linear_jsd_bwd:
   op: fused_linear_jsd
   args: --op fused_linear_jsd --baseline torch_lm_head_jsd --metrics speedup --bwd
-    --only liger_lm_head_jsd,torch_lm_head_jsd,torch_lm_head_jsd
+    --only liger_lm_head_jsd,torch_lm_head_jsd
 geglu_bwd:
   op: geglu
-  args: --op geglu --baseline torch_geglu --metrics speedup --bwd --only liger_geglu,torch_geglu,torch_geglu
+  args: --op geglu --baseline torch_geglu --metrics speedup --bwd --only liger_geglu,torch_geglu
 jsd_bwd:
   op: jsd
-  args: --op jsd --baseline torch_jsd --metrics speedup --bwd --only liger_jsd,torch_jsd,torch_jsd
+  args: --op jsd --baseline torch_jsd --metrics speedup --bwd --only liger_jsd,torch_jsd
 kl_div_bwd:
   op: kl_div
-  args: --op kl_div --baseline torch_kl_div --metrics speedup --bwd --only liger_kl_div,torch_kl_div,torch_kl_div
+  args: --op kl_div --baseline torch_kl_div --metrics speedup --bwd --only liger_kl_div,torch_kl_div
 layer_norm_bwd:
   op: layer_norm
   args: --op layer_norm --baseline torch_layer_norm --metrics speedup --bwd --only
@@ -125,7 +125,7 @@ rms_norm_bwd:
   args: --op rms_norm --baseline llama_rms --metrics speedup --bwd --only liger_rms,llama_rms,llama_rms
 rope_bwd:
   op: rope
-  args: --op rope --baseline apply_rotary_pos_emb --metrics speedup --bwd --only liger_rotary_pos_emb,apply_rotary_pos_emb,apply_rotary_pos_emb
+  args: --op rope --baseline apply_rotary_pos_emb --metrics speedup --bwd --only liger_rotary_pos_emb,apply_rotary_pos_emb
 swiglu_bwd:
   op: swiglu
-  args: --op swiglu --baseline torch_swiglu --metrics speedup --bwd --only liger_swiglu,torch_swiglu,torch_swiglu
+  args: --op swiglu --baseline torch_swiglu --metrics speedup --bwd --only liger_swiglu,torch_swiglu

--- a/benchmarks/nightly/autogen.yaml
+++ b/benchmarks/nightly/autogen.yaml
@@ -17,19 +17,22 @@ bf16_flex_attention_fwd:
 bf16_ragged_attention_fwd:
   op: ragged_attention
   args: --op ragged_attention --metrics tflops --only hstu
-fp8_gemm_fwd:
-  op: fp8_gemm
-  args: --op fp8_gemm --baseline torch_fp8_gemm --metrics tflops,speedup --only triton_tma_persistent_fp8_gemm,torch_fp8_gemm
+# fbgemm fp8_gemm does not work on the latest triton main
+# fp8_gemm_fwd:
+#   op: fp8_gemm
+#   args: --op fp8_gemm --baseline torch_fp8_gemm --metrics tflops,speedup --only triton_tma_persistent_fp8_gemm,torch_fp8_gemm
 fp8_gemm_blockwise_fwd:
   op: fp8_gemm_blockwise
   args: --op fp8_gemm_blockwise --baseline _cutlass --metrics tflops,speedup --only
     _triton,_cutlass
-fp8_gemm_rowwise_fwd:
-  op: fp8_gemm_rowwise
-  args: --op fp8_gemm_rowwise --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
-fp8_gemm_rowwise_grouped_fwd:
-  op: fp8_gemm_rowwise_grouped
-  args: --op fp8_gemm_rowwise_grouped --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
+# fbgemm fp8_gemm_rowwise does not work on the latest triton main
+# fp8_gemm_rowwise_fwd:
+#   op: fp8_gemm_rowwise
+#   args: --op fp8_gemm_rowwise --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
+# fbgemm fp8_gemm_rowwise_grouped does not work on the latest triton main
+# fp8_gemm_rowwise_grouped_fwd:
+#   op: fp8_gemm_rowwise_grouped
+#   args: --op fp8_gemm_rowwise_grouped --baseline _cutlass_or_ck --metrics tflops,speedup --only _triton,_cutlass_or_ck
 fused_linear_cross_entropy_fwd:
   op: fused_linear_cross_entropy
   args: --op fused_linear_cross_entropy --baseline torch_lm_head_ce --metrics speedup
@@ -85,9 +88,10 @@ cross_entropy_bwd:
 embedding_bwd:
   op: embedding
   args: --op embedding --baseline torch_embedding --metrics speedup --bwd --only liger_embedding,torch_embedding,torch_embedding
+# flash_attention triton bwd only works with causal
 bf16_flash_attention_bwd:
   op: flash_attention
-  args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --bwd --only triton_tutorial_flash_v2,flash_v3
+  args: --op flash_attention --baseline flash_v3 --metrics tflops,speedup --bwd --only triton_tutorial_flash_v2,flash_v3 --causal
 bf16_flex_attention_bwd:
   op: flex_attention
   args: --op flex_attention --baseline eager --metrics tflops,speedup --bwd --only

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -874,7 +874,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 self.baseline_metrics = None
                 self._op_flops = {}
                 if self._only:
-                    benchmarks = self._only
+                    benchmarks = list(set(self._only))  # remove duplicates
                 else:
                     benchmarks = find_enabled_benchmarks(
                         self.mode, REGISTERED_BENCHMARKS[self.name], self._skip


### PR DESCRIPTION
BE efforts enables more tests in nightly.

Note that we can't enable a couple of fp8_* operators from FBGEMM, because FBGEMM Triton code still uses the old TMA API and therefore can't work on Triton main.

Test plan:

https://github.com/pytorch-labs/tritonbench/actions/runs/16037334650/job/45251972846?pr=251