### PR TITLE
Support old triton versions w/ setup.py in ./python

### DIFF
--- a/.ci/triton/compile.sh
+++ b/.ci/triton/compile.sh
@@ -37,7 +37,14 @@ install_triton() {
     # install main triton
     pip install ninja cmake wheel pybind11; # build-time dependencies
     pip install -r python/requirements.txt
+    # old versions of triton have setup.py in ./python; newer versions in ./
+    if [ ! -f setup.py ]; then
+      pushd python
+    else
+      pushd .
+    fi
     pip install -e .
+    popd
 }
 
 # Parse arguments


### PR DESCRIPTION
I want to ab test triton 3.3 and triton 3.4 to look for perf regressions or failures not caught in PyTorch CI. But Triton 3.3 is too old for the existing setup script, which assumes setup.py in the ./ directory (in triton 3.3, it's in ./python/setup.py).

This PR adds support to build either version.

before (fails to compile 3.3): https://github.com/pytorch-labs/tritonbench/actions/runs/16012761341
after (succeeds in compiling 3.3): https://github.com/pytorch-labs/tritonbench/actions/runs/16013163616