### PR TITLE
[FA] Add code to enable autoWS from triton-lang

### DIFF
--- a/tritonbench/kernels/attention_utils.py
+++ b/tritonbench/kernels/attention_utils.py
@@ -15,7 +15,7 @@ HAS_TMA_DESC = "nv_tma_desc_type" in dir(tl)
 WITH_COMPPIPE = os.getenv("ENABLE_COMPPIPE")
 PEEL_LAST = os.getenv("PEEL_LAST_ITER")
 WITH_TMA = os.getenv("WITH_TMA")
-HAS_AUTO_WS = os.getenv("ENABLE_AUTO_WS")
+HAS_EXPLICIT_WS = os.getenv("ENABLE_EXPLICIT_WS")
 
 
 class TmaAutoTuneHelper:

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -346,7 +346,7 @@ def get_fwd_config_space(
 ):
     configs = []
     bmList = [128] if enable_ws else [64, 128]
-    bnList = [64, 128] # To handle hDim of 64, we need BLOCK_N to be <= 64
+    bnList = [64, 128]  # To handle hDim of 64, we need BLOCK_N to be <= 64
     wList = [4] if enable_ws else [4, 8]
     stageList = [2] if enable_ws else [3, 4, 7]
     for BM in bmList:
@@ -1104,6 +1104,7 @@ def _attn_fwd_base_opt(
         False,  # WARP_SPECIALIZE
     )
 
+
 def prune_invalid_configs(configs, named_args, **kwargs):
     ENABLE_WS = kwargs["ENABLE_WS"]
     # Choose configsTmaWS when ENABLE_WS is True
@@ -1114,8 +1115,11 @@ def prune_invalid_configs(configs, named_args, **kwargs):
 
 # when ENABLE_WS is true, we can't use configsTma
 # use either configsTma or configsTmaWS, not configsTma + configsTmaWS
-@triton.autotune(list(filter(keep, configsTma + configsTmaWS)), key=["N_CTX"],
-                 prune_configs_by={'early_config_prune': prune_invalid_configs})
+@triton.autotune(
+    list(filter(keep, configsTma + configsTmaWS)),
+    key=["N_CTX"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+)
 @triton.jit
 def _attn_fwd_tma_unified(
     Q,

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -29,8 +29,6 @@ from .attention_utils import (
     WITH_TMA,
 )
 
-# if we want to use tl.async_task, set env var HAS_EXPLICIT_WS
-# if we want to use warp_specialize on ForOp, set env var HAS_AUTO_WS
 
 if HAS_TMA_DESC:
     print(

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -995,7 +995,7 @@ def _attn_fwd_ws(
             STAGE,
             ENABLE_TMA,
             LOOP_SCHEDULE,
-            False, # warp_specialize on hopper is not ready yet
+            False,  # warp_specialize on hopper is not ready yet
         )
 
 
@@ -1282,7 +1282,7 @@ def _attn_fwd_tma_unified(
                 STAGE,
                 ENABLE_TMA,
                 LOOP_SCHEDULE,
-                False, # warp_specialize on hopper is not ready yet
+                False,  # warp_specialize on hopper is not ready yet
             )
     else:
         _attn_fwd_compute(
@@ -1500,7 +1500,7 @@ def _attn_fwd_tma_ws_persistent(  # Q, V, desc_k, desc_v, sm_scale, M, Out,  #
                 STAGE,
                 ENABLE_TMA,
                 LOOP_SCHEDULE,
-                False, # warp_specialize on hopper is not ready yet
+                False,  # warp_specialize on hopper is not ready yet
             )
         tile_idx += num_progs
 

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -346,7 +346,7 @@ def get_fwd_config_space(
 ):
     configs = []
     bmList = [128] if enable_ws else [64, 128]
-    bnList = [128] if enable_ws else [64, 128]
+    bnList = [64, 128] # To handle hDim of 64, we need BLOCK_N to be <= 64
     wList = [4] if enable_ws else [4, 8]
     stageList = [2] if enable_ws else [3, 4, 7]
     for BM in bmList:
@@ -1103,9 +1103,18 @@ def _attn_fwd_base_opt(
         False,  # WARP_SPECIALIZE
     )
 
+def prune_invalid_configs(configs, named_args, **kwargs):
+    ENABLE_WS = kwargs["ENABLE_WS"]
+    # Choose configsTmaWS when ENABLE_WS is True
+    if ENABLE_WS:
+        return [conf for conf in configs if conf in configsTmaWS]
+    return [conf for conf in configs if conf in configsTma]
+
 
 # when ENABLE_WS is true, we can't use configsTma
-@triton.autotune(list(filter(keep, configsTma + configsTmaWS)), key=["N_CTX"])
+# use either configsTma or configsTmaWS, not configsTma + configsTmaWS
+@triton.autotune(list(filter(keep, configsTma + configsTmaWS)), key=["N_CTX"],
+                 prune_configs_by={'early_config_prune': prune_invalid_configs})
 @triton.jit
 def _attn_fwd_tma_unified(
     Q,

--- a/tritonbench/kernels/triton_fused_attention.py
+++ b/tritonbench/kernels/triton_fused_attention.py
@@ -995,7 +995,7 @@ def _attn_fwd_ws(
             STAGE,
             ENABLE_TMA,
             LOOP_SCHEDULE,
-            True,
+            False, # warp_specialize on hopper is not ready yet
         )
 
 
@@ -1282,7 +1282,7 @@ def _attn_fwd_tma_unified(
                 STAGE,
                 ENABLE_TMA,
                 LOOP_SCHEDULE,
-                True,  # WARP_SPECIALIZE
+                False, # warp_specialize on hopper is not ready yet
             )
     else:
         _attn_fwd_compute(
@@ -1500,7 +1500,7 @@ def _attn_fwd_tma_ws_persistent(  # Q, V, desc_k, desc_v, sm_scale, M, Out,  #
                 STAGE,
                 ENABLE_TMA,
                 LOOP_SCHEDULE,
-                True,
+                False, # warp_specialize on hopper is not ready yet
             )
         tile_idx += num_progs
 


### PR DESCRIPTION
Also clean up setting up configs for different optimization variants.
- Extract computation in inner loop as a helper function attn_fwd_iteration
- We have 3 different versions of attn_fwd_inner: attn_fwd_inner[_autows|_ws], _autows is for OSS triton where we use warp_specialize on ForOp to enable warpspec, _ws is for internal triton, where we use tl.async_task and num_consumer_groups to enable warpspec
- We have 2 different versions of attn_fwd_compute: attn_fwd_compute[_ws], attn_fwd_compute_ws calls attn_fwd_inner_ws, attn_fwd_compute calls either attn_fwd_inner or attn_fwd_inner_autows depending on whether warpspec should be enabled via argument WARP_SPECIALIZE
- We have 4 top-level kernels: _attn_fwd_ws, _attn_fwd_base_opt, _attn_fwd_tma_unified, _attn_fwd_tma_ws_persistent
- Depending on env var ENABLE_EXPLICIT_WS, _attn_fwd_ws will call either _attn_fwd_compute_ws or attn_fwd_compute with WARP_SPECIALIZE=True

```
TRITON_PRINT_AUTOTUNING=1 WITH_TMA=1 CUDA_VISIBLE_DEVICES=5 TORCH_CUDA_ARCH_LIST=9.0a ./denoise.sh python run.py --op flash_attention --only triton_tutorial_flash_v2_tma_ws_persistent,triton_tutorial_flash_v2_tma_ws --num-inputs 1 --seq-len 8192 --metrics tflops --batch 8 --n-heads 16 --d-head 128
  (Batch, Heads, SeqLen, SeqLen_KV, Dhead)    triton_tutorial_flash_v2_tma_ws_persistent-tflops    triton_tutorial_flash_v2_tma_ws-tflops
------------------------------------------  ---------------------------------------------------  ----------------------------------------
                  (8, 16, 8192, 8192, 128)                                              517.261                                   499.359
```