### PR TITLE
fix ab test: "side_b_commit"

### DIFF
--- a/.github/workflows/_linux-benchmark-abtest-h100.yml
+++ b/.github/workflows/_linux-benchmark-abtest-h100.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf .benchmarks || true
       - name: Compile Triton (Side B)
         run: |
-          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_a_commit }} --side b
+          bash ./.ci/triton/compile.sh --repo ${{ inputs.side_a_triton }} --commit ${{ inputs.side_b_commit }} --side b
       - name: Benchmark Triton (Side B)
         run: |
           bash ./.ci/tritonbench/run-benchmark.sh ${{ inputs.benchmark_name }} --conda-env triton-side-b


### PR DESCRIPTION
Previously both the "A Side" and "B Side" were running off the same Triton commit - this updates the "B Side" to actually use the side_b_commit instead of the side_a_commit