### PR TITLE
[be] Reorganize logging dir

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -224,9 +224,11 @@ def get_parser(args=None):
         help="Load input file from Tritonbench data JSON.",
     )
     parser.add_argument(
-        "--logging-group", type=str, default=None, help="Name of group for benchmarking."
+        "--logging-group",
+        type=str,
+        default=None,
+        help="Name of group for benchmarking.",
     )
-
 
     if is_fbcode():
         parser.add_argument("--log-scuba", action="store_true", help="Log to scuba.")

--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -223,15 +223,13 @@ def get_parser(args=None):
         type=str,
         help="Load input file from Tritonbench data JSON.",
     )
+    parser.add_argument(
+        "--logging-group", type=str, default=None, help="Name of group for benchmarking."
+    )
+
 
     if is_fbcode():
         parser.add_argument("--log-scuba", action="store_true", help="Log to scuba.")
-        parser.add_argument(
-            "--logging-group",
-            type=str,
-            default=None,
-            help="Override default name for logging in scuba.",
-        )
         parser.add_argument(
             "--production-shapes",
             action="store_true",

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1108,7 +1108,8 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
     def benchmark_name(self, default: bool = False) -> str:
         if not default and self.tb_args.benchmark_name:
             return self.tb_args.benchmark_name
-        return f"{self.precision}_{self.name}_{self.mode}"
+        parts = [x for x in [self.precision, self.name, self.mode.value] if x]
+        return "_".join(parts)
 
     @property
     def logging_group(self) -> Optional[str]:

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -1087,7 +1087,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def get_temp_path(
         self,
-        fn_name: Optional[str]=None,
+        fn_name: Optional[str] = None,
     ) -> Path:
         unix_user: Optional[str] = os.environ.get("USER", None)
         logging_group: Optional[str] = self.logging_group
@@ -1095,7 +1095,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         tritonbench_dir_name = "_".join(parts)
         benchmark_name = self.benchmark_name
         fn_part = f"{fn_name}_{self._input_id}" if fn_name else ""
-        out_part = Path(tempfile.gettempdir()) / tritonbench_dir_name / benchmark_name 
+        out_part = Path(tempfile.gettempdir()) / tritonbench_dir_name / benchmark_name
         return out_part / fn_part if fn_part else out_part
 
     @property
@@ -1105,7 +1105,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         return self.tb_args.precision
 
     @property
-    def benchmark_name(self, default: bool=False) -> str:
+    def benchmark_name(self, default: bool = False) -> str:
         if not default and self.tb_args.benchmark_name:
             return self.tb_args.benchmark_name
         return f"{self.precision}_{self.name}_{self.mode}"

--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -616,18 +616,6 @@ def register_benchmark(
     return decorator
 
 
-def register_benchmark_manually(
-    operator_name: str,
-    func_name: str,
-    baseline: bool = False,
-    enabled: bool = True,
-    label: Optional[str] = None,
-):
-    return register_benchmark(
-        operator_name, func_name, baseline, enabled, fwd_only=False, label=label
-    )
-
-
 def register_metric(
     # Metrics that only apply to non-baseline impls
     # E.g., accuracy, speedup
@@ -1097,13 +1085,18 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         except StopIteration:
             return None
 
-    def get_temp_path(self, path: Union[str, Path]) -> Path:
+    def get_temp_path(
+        self,
+        fn_name: Optional[str]=None,
+    ) -> Path:
         unix_user: Optional[str] = os.environ.get("USER", None)
         logging_group: Optional[str] = self.logging_group
         parts = [x for x in ["tritonbench", unix_user, logging_group] if x]
         tritonbench_dir_name = "_".join(parts)
         benchmark_name = self.benchmark_name
-        return Path(tempfile.gettempdir()) / tritonbench_dir_name / benchmark_name / Path(path)
+        fn_part = f"{fn_name}_{self._input_id}" if fn_name else ""
+        out_part = Path(tempfile.gettempdir()) / tritonbench_dir_name / benchmark_name 
+        return out_part / fn_part if fn_part else out_part
 
     @property
     def precision(self) -> str:
@@ -1352,7 +1345,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                     do_compile_kineto_trace_in_task,
                 )
 
-                kineto_trace_output_dir = self.get_temp_path("kineto_trace")
+                kineto_trace_output_dir = self.get_temp_path(fn_name)
                 kineto_trace_output_dir.mkdir(parents=True, exist_ok=True)
                 metrics.extra_metrics["_compile_time_kineto_trace_in_task"] = (
                     do_compile_kineto_trace_in_task(
@@ -1583,10 +1576,10 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def nsys_rep(self, input_id: int, fn_name: str) -> str:
         op_task_args = self._get_op_task_args(input_id, fn_name, "_nsys_rep_in_task")
-        nsys_output_dir = self.get_temp_path(f"nsys_traces/{fn_name}_{input_id}")
+        nsys_output_dir = self.get_temp_path(fn_name)
         nsys_output_dir.mkdir(parents=True, exist_ok=True)
         ext = ".nsys-rep"
-        nsys_output_file = nsys_output_dir.joinpath(f"nsys_output{ext}").resolve()
+        nsys_output_file = nsys_output_dir.joinpath(f"nsys_rep{ext}").resolve()
         nsys_trace_cmd = [
             "nsys",
             "profile",
@@ -1660,11 +1653,11 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                 logger.warn(
                     "DCGM may not have been successfully disabled. Proceeding to collect NCU trace anyway..."
                 )
-        ncu_output_dir = self.get_temp_path(f"ncu_traces/{fn_name}_{input_id}")
+        ncu_output_dir = self.get_temp_path(fn_name)
         ncu_output_dir.mkdir(parents=True, exist_ok=True)
         ext = ".csv" if not replay else ".ncu-rep"
         ncu_output_file = ncu_output_dir.joinpath(
-            f"ncu_output{'_ir' if profile_ir else ''}{ext}"
+            f"ncu_rep{'_ir' if profile_ir else ''}{ext}"
         ).resolve()
         ncu_args = [
             "ncu",
@@ -1707,14 +1700,14 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
 
     def att_trace(self, input_id: int, fn_name: str) -> str:
         op_task_args = self._get_op_task_args(input_id, fn_name, "_ncu_trace_in_task")
-        att_output_dir = self.get_temp_path(f"att_traces/{fn_name}_{input_id}")
+        att_output_dir = self.get_temp_path(fn_name)
         att_trace_dir = launch_att(att_output_dir, op_task_args)
         return att_trace_dir
 
     def kineto_trace(self, input_id: int, fn: Callable) -> str:
         from tritonbench.components.kineto import do_bench_kineto
 
-        kineto_output_dir = self.get_temp_path(f"kineto_traces/{fn._name}_{input_id}")
+        kineto_output_dir = self.get_temp_path(fn._name)
         kineto_output_dir.mkdir(parents=True, exist_ok=True)
         return do_bench_kineto(
             fn=fn,
@@ -1855,7 +1848,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
             fn()
 
         if len(compiled_kernels) > 0:
-            ir_dir = self.get_temp_path("ir")
+            ir_dir = self.get_temp_path(fn._name)
             ir_dir.mkdir(parents=True, exist_ok=True)
             logger.info(
                 "Writing %s Triton IRs to %s",


### PR DESCRIPTION
Organize the logging directory. Now log to `/tmp/tritonbench_$USER_$LOGGING_GROUP/$BENCHMARK_NAME/$BACKEND_$INPUT_XVAL/$METRIC.<extension>`.


Fixes https://github.com/pytorch-labs/tritonbench/issues/94

Test plan:

```
$ python run.py --op softmax --only triton_softmax --num-inputs 1 --metrics kineto_trace,ncu_rep
  x_val                           triton_softmax-kineto_trace                                                triton_softmax-ncu_rep
-------  ----------------------------------------------------  --------------------------------------------------------------------
 2176.0  /tmp/tritonbench_xzhao9/softmax_fwd/triton_softmax_0  /tmp/tritonbench_xzhao9/softmax_fwd/triton_softmax_0/ncu_rep.ncu-rep

$ tree -L 3 /tmp/tritonbench_xzhao9/
/tmp/tritonbench_xzhao9/
└── softmax_fwd
    └── triton_softmax_0
        ├── devvm3059.eag0.facebook.com_1351975.1752690766606139153.pt.trace.json
        ├── devvm3059.eag0.facebook.com_1357864.1752690851550292231.pt.trace.json
        ├── devvm3059.eag0.facebook.com_1358481.1752690861764172111.pt.trace.json
        ├── devvm3059.eag0.facebook.com_1376058.1752691079417859893.pt.trace.json
        └── ncu_rep.ncu-rep

2 directories, 5 files
```
