### PR TITLE
Use AsyncTaskContext to replace tl.async_task usage

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,27 +10,7 @@ import os
 import sys
 from typing import List
 
-# Apply async_task patch for Triton 3.4+ compatibility
-import triton.language as tl
-
 from tritonbench.operator_loader import get_op_loader_bench_cls_by_name, is_loader_op
-
-if not hasattr(tl, "async_task"):
-
-    class _AsyncTaskContext:
-        """A no-op context manager to replace tl.async_task"""
-
-        def __init__(self, task_ids):
-            self.task_ids = task_ids
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            return False
-
-    # Add async_task to triton.language
-    tl.async_task = lambda task_ids: _AsyncTaskContext(task_ids)
 
 from tritonbench.operators import load_opbench_by_name
 from tritonbench.operators_collection import list_operators_by_collection

--- a/tritonbench/utils/triton_utils.py
+++ b/tritonbench/utils/triton_utils.py
@@ -1,5 +1,27 @@
 # utils to identify triton versions
 
+import triton.language as tl
+
+
+class AsyncTaskContext:
+    """Context manager that dispatches to tl.async_task if available, otherwise no-op."""
+
+    def __init__(self, task_ids):
+        self.task_ids = task_ids
+        self._has_async_task = hasattr(tl, "async_task")
+        self._context = None
+
+    def __enter__(self):
+        if self._has_async_task:
+            self._context = tl.async_task(self.task_ids)
+            return self._context.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._has_async_task and self._context is not None:
+            return self._context.__exit__(exc_type, exc_val, exc_tb)
+        return False
+
 
 def has_warp_spec():
     import triton.language as tl


### PR DESCRIPTION
Inductor relies on `tl.async_task` existence check to gate specific functionalities, so we can't monkey-patch a no-op `tl.async_task`. Switched to use a `AsyncTaskContext` ctx manager that will dispatch appropriately instead.