### PR TITLE
[backends] Add Quack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/aiter"]
 	path = submodules/aiter
 	url = https://github.com/ROCm/aiter.git
+[submodule "submodules/quack"]
+	path = submodules/quack
+	url = https://github.com/Dao-AILab/quack.git

--- a/install.py
+++ b/install.py
@@ -198,6 +198,11 @@ if __name__ == "__main__":
     if args.liger or args.all:
         logger.info("[tritonbench] installing liger-kernels...")
         install_liger()
+    if args.quack or args.all:
+        logger.info("[tritonbench] installing quack...")
+        from tools.quack.install import install_quack
+
+        install_quack()
     if args.xformers:
         logger.info("[tritonbench] installing xformers...")
         from tools.xformers.install import install_xformers

--- a/tools/quack/install.py
+++ b/tools/quack/install.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+
+from pathlib import Path
+
+
+REPO_PATH = Path(os.path.abspath(__file__)).parent.parent.parent
+CURRENT_DIR = Path(os.path.abspath(__file__)).parent
+QUACK_PATH = REPO_PATH.joinpath("submodules", "quack")
+
+
+def install_quack():
+    cmd = ["pip", "install", "-e", "."]
+    subprocess.check_call(cmd, cwd=QUACK_PATH)

--- a/tritonbench/operators/rms_norm/operator.py
+++ b/tritonbench/operators/rms_norm/operator.py
@@ -23,6 +23,11 @@ try:
 except ModuleNotFoundError:
     HAS_AITER = False
 
+try:
+    from .quack import QuackRMSNorm
+except ModuleNotFoundError:
+    QuackRMSNorm = None
+
 
 # Reference: https://github.com/linkedin/Liger-Kernel/
 # blob/main/benchmark/scripts/benchmark_rms_norm.py
@@ -71,6 +76,11 @@ class Operator(BenchmarkOperator):
     def liger_rms(self, H, input) -> Callable:
         self.liger_rms_op = LigerRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
         return lambda: self.liger_rms_op(input)
+
+    @register_benchmark(enabled=QuackRMSNorm)
+    def quack_rms(self, H, input) -> Callable:
+        self.quack_rms_op = QuackRMSNorm(hidden_size=H, eps=self.eps).to(self.device)
+        return lambda: self.quack_rms_op(input)
 
     @register_benchmark()
     def inductor_rms(self, H, input) -> Callable:

--- a/tritonbench/operators/rms_norm/quack.py
+++ b/tritonbench/operators/rms_norm/quack.py
@@ -1,0 +1,16 @@
+import torch
+
+from quack import rmsnorm as quack_rmsnorm
+
+
+class QuackRMSNorm(torch.nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        AITerRMSNorm
+        """
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        return quack_rmsnorm(hidden_states, self.weight, self.variance_epsilon)

--- a/tritonbench/operators/softmax/operator.py
+++ b/tritonbench/operators/softmax/operator.py
@@ -15,6 +15,13 @@ from tritonbench.utils.triton_op import (
     register_metric,
 )
 
+try:
+    from quack.softmax import softmax as quack_softmax
+
+    HAS_QUACK = True
+except ImportError:
+    HAS_QUACK = False
+
 
 class Operator(BenchmarkOperator):
     is_compute_bound = False
@@ -104,6 +111,11 @@ class Operator(BenchmarkOperator):
             return ret
 
         return _inner
+
+    @register_benchmark(enabled=HAS_QUACK)
+    def quack(self, x):
+        inner = lambda: quack_softmax(x)
+        return inner
 
     def get_input_iter(self):
         M = 4096


### PR DESCRIPTION
Add Quack submodules to support Cute-DSL.


Test Plan:
```
python run.py --op softmax --only quack,triton_softmax --baseline triton_softmax --metrics speedup,accuracy

 x_val    quack-speedup    quack-accuracy
-------  ---------------  ----------------
 2176.0         1.03607                  1
 2240.0         1.00836                  1
 2304.0         1.02963                  1
 2368.0         1.06787                  1
 2432.0         1.07566                  1
 2496.0         1.06972                  1
 2560.0         1.03583                  1
 2624.0         1.11346                  1
 2688.0         1.11142                  1
 2752.0         1.0969                   1
 2816.0         1.05758                  1
 2880.0         1.05275                  1
 2944.0         1.05187                  1
 3008.0         1.04094                  1
 3072.0         1.03789                  1
 3136.0         1.05424                  1
 3200.0         1.05045                  1
 3264.0         1.05934                  1
 3328.0         1.05712                  1
 3392.0         1.04964                  1
 3456.0         1.04263                  1
 3520.0         1.03758                  1
 3584.0         1.02486                  1
 3648.0         1.04291                  1
 3712.0         1.03782                  1
 3776.0         1.03064                  1
 3840.0         1.03085                  1
 3904.0         1.03091                  1
 3968.0         1.02681                  1
 4032.0         1.02391                  1
 4096.0         1.0306                   1
 4160.0         1.02494                  1
 4224.0         1.02854                  1
 4288.0         1.03058                  1
 4352.0         1.03786                  1
 4416.0         1.02904                  1
 4480.0         1.02867                  1
 4544.0         1.00729                  1
 4608.0         1.02317                  1
 4672.0         1.01277                  1
 4736.0         1.047                    1
 4800.0         1.02288                  1
 4864.0         1.02121                  1
 4928.0         1.02152                  1
 4992.0         1.02391                  1
 5056.0         0.998667                 1
 5120.0         1.00935                  1
 5184.0         1.01675                  1
 5248.0         1.0213                   1
 5312.0         1.04653                  1
 5376.0         1.03314                  1
 5440.0         1.03847                  1
 5504.0         1.03788                  1
 5568.0         1.01968                  1
 5632.0         1.01937                  1
 5696.0         1.01666                  1
 5760.0         1.01524                  1
 5824.0         1.01804                  1
 5888.0         1.02032                  1
 5952.0         1.01773                  1
 6016.0         1.02064                  1
 6080.0         1.0203                   1
 6144.0         1.02565                  1
 6208.0         1.0269                   1
 6272.0         1.02349                  1
 6336.0         1.02017                  1
 6400.0         1.03121                  1
 6464.0         1.0222                   1
 6528.0         1.01929                  1
 6592.0         1.02045                  1
 6656.0         1.01652                  1
 6720.0         1.01696                  1
 6784.0         1.01408                  1
 6848.0         1.0128                   1
 6912.0         1.01524                  1
 6976.0         1.01097                  1
 7040.0         1.00916                  1
 7104.0         1.01154                  1
 7168.0         1.01079                  1
 7232.0         1.00985                  1
 7296.0         1.00854                  1
 7360.0         1.00982                  1
 7424.0         1.01009                  1
 7488.0         1.01016                  1
 7552.0         1.0093                   1
 7616.0         1.009                    1
 7680.0         1.00872                  1
 7744.0         1.00918                  1
 7808.0         1.00909                  1
 7872.0         1.00753                  1
 7936.0         1.00851                  1
 8000.0         0.997222                 1
 8064.0         0.998455                 1
 8128.0         0.996948                 1
 8192.0         1.00084                  1
 8256.0         0.997337                 1
 8320.0         0.9967                   1
 8384.0         0.998042                 1
average         1.02702                  1
```


```
$ python run.py --op rms_norm --only quack_rms,liger_rms --baseline liger_rms --metrics latency,speedup,accuracy
       (M, H)    liger_rms-latency    quack_rms-accuracy    quack_rms-latency    quack_rms-speedup
-------------  -------------------  --------------------  -------------------  -------------------
 (2048, 1024)    0.013024 (±5.90%)                     1    0.012512 (±8.18%)             1.04092
 (2048, 2048)    0.020736 (±4.48%)                     1    0.020832 (±5.22%)             0.995392
 (2048, 4096)    0.036448 (±3.16%)                     1    0.036416 (±3.34%)             1.00088
 (2048, 8192)    0.066944 (±1.91%)                     1    0.066400 (±2.31%)             1.00819
(2048, 16384)    0.129216 (±2.67%)                     1    0.129856 (±3.03%)             0.995071
(2048, 32768)    0.267264 (±1.52%)                     1    0.252320 (±1.90%)             1.05923
      average                                          1                                  1.01661
```