### PR TITLE
[Fix] Add parser.add_argument for Quack

### DIFF
--- a/install.py
+++ b/install.py
@@ -143,6 +143,7 @@ if __name__ == "__main__":
     parser.add_argument("--jax", action="store_true", help="Install jax nightly")
     parser.add_argument("--tk", action="store_true", help="Install ThunderKittens")
     parser.add_argument("--liger", action="store_true", help="Install Liger-kernel")
+    parser.add_argument("--quack", action="store_true", help="install quack")
     parser.add_argument("--xformers", action="store_true", help="Install xformers")
     parser.add_argument("--tile", action="store_true", help="install tile lang")
     parser.add_argument("--aiter", action="store_true", help="install AMD's aiter")


### PR DESCRIPTION
My docker is failing with the following error when it runs install.py.
71.11 File "/app/tritonbench/install.py", line 201, in
71.11 if args.quack or args.all:
71.11 AttributeError: 'Namespace' object has no attribute 'quack'

Added a parser argument for quack.