### PR TITLE
[TritonParse] Enable Launch Tracing, Default Parsing, and Enhanced Docs

### DIFF
--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -1,9 +1,23 @@
+"""
+This module provides utility functions for integrating with TritonParse.
+TritonParse is a tool for tracing, visualizing, and analyzing Triton kernels.
+For more details, see: https://github.com/pytorch-labs/tritonparse
+"""
 import importlib.util
-
-from tritonbench.utils.env_utils import is_fbcode
 
 
 def tritonparse_init(tritonparse_log_path):
+    """Initializes TritonParse structured logging.
+
+    This function sets up the logging hook to capture Triton compilation
+    and launch events. For more details, see:
+    https://github.com/pytorch-labs/tritonparse
+
+    Args:
+        tritonparse_log_path (str or None): The path to the directory where
+            TritonParse logs should be stored. If None, this function
+            does nothing.
+    """
     if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
         try:
@@ -25,6 +39,17 @@ def tritonparse_init(tritonparse_log_path):
 
 
 def tritonparse_parse(tritonparse_log_path):
+    """Parses the generated TritonParse logs.
+
+    This function processes the raw logs generated during the run and
+    creates unified, structured trace files. For more details, see:
+    https://github.com/pytorch-labs/tritonparse
+
+    Args:
+        tritonparse_log_path (str or None): The path to the directory containing
+            the TritonParse logs to be parsed. If None, this function
+            does nothing.
+    """
     if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
         try:

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -25,7 +25,7 @@ def tritonparse_init(tritonparse_log_path):
 
 
 def tritonparse_parse(tritonparse_log_path):
-    if tritonparse_log_path is not None and is_fbcode():
+    if tritonparse_log_path is not None:
         # capture errors but don't fail the entire script
         try:
             from tritonparse.utils import unified_parse

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -15,7 +15,7 @@ def tritonparse_init(tritonparse_log_path):
             import tritonparse.structured_logging
 
             tritonparse.structured_logging.init(
-                tritonparse_log_path, enable_launch_trace=True
+                tritonparse_log_path, enable_trace_launch=True
             )
             print(
                 f"TritonParse structured logging initialized with log path: {tritonparse_log_path}"

--- a/tritonbench/utils/tritonparse_utils.py
+++ b/tritonbench/utils/tritonparse_utils.py
@@ -14,7 +14,9 @@ def tritonparse_init(tritonparse_log_path):
                 return
             import tritonparse.structured_logging
 
-            tritonparse.structured_logging.init(tritonparse_log_path)
+            tritonparse.structured_logging.init(
+                tritonparse_log_path, enable_launch_trace=True
+            )
             print(
                 f"TritonParse structured logging initialized with log path: {tritonparse_log_path}"
             )


### PR DESCRIPTION

This pull request significantly enhances the TritonParse integration with three key improvements: enabling kernel launch tracing, activating default log parsing for open-source users, and adding comprehensive documentation.

## Key Changes:

- **Enable Launch Tracing:** The `enable_trace_launch=True` parameter has been added to the logging initialization. This provides deeper insights into kernel execution by tracing launch parameters, which is critical for performance analysis and debugging.

- **Default Log Parsing for OSS Users:** The `unified_parse` function is now called by default for open-source users, streamlining the process of generating structured trace files from raw logs. This makes kernel analysis more accessible out-of-the-box.

- **Improved Documentation:** To improve clarity and ease of use, the `tritonparse_utils.py` module has been updated with a module-level docstring and detailed function docstrings, including links to the official TritonParse repository.

These updates make our TritonParse integration more powerful and user-friendly, both for internal debugging and for the open-source community. 


## Test Plan:

```bash
% python run.py --op vector_add --tritonparse --num-inputs 1
TritonParse structured logging initialized with log path: ./tritonparse_logs/
  0%|                                                                                                                           | 0/1 [00:00<?, ?it/s]INFO:tritonbench.utils.triton_op:Took 0.00ms to get benchmark function for torch_add
Removed 17 outliers from 73 samples
INFO:tritonbench.utils.triton_op:Took 0.06ms to get benchmark function for triton_add
Removed 6 outliers from 150 samples
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.72s/it]
  x_val    torch_add-latency                                                torch_add-gbps    triton_add-latency                                                 triton_add-gbps
-------  -------------------  ------------------------------------------------------------  --------------------  --------------------------------------------------------------
   4096    0.004096 (±2.34%)  (12.000000030297088, 11.725191428954378, 12.094487559086616)    0.127136 (±12.36%)  (0.38660959376217846, 0.34501348433868717, 0.4411257934534067)
average
tritonparse log file list: /tmp/tmpl94j1siu/log_file_list.json

================================================================================
📁 TRITONPARSE PARSING RESULTS
================================================================================
📂 Parsed files directory: /tmp/tmpl94j1siu
📊 Total files generated: 2

📄 Generated files:
--------------------------------------------------
   1. 📝 dedicated_log_triton_trace_findhao__mapped.ndjson.gz (33.2KB)
   2. 📝 log_file_list.json (181B)
================================================================================
✅ Parsing completed successfully!
================================================================================

```