### PR TITLE
nit: Fix whitespace indentation

### DIFF
--- a/tritonbench/utils/list_operator_details.py
+++ b/tritonbench/utils/list_operator_details.py
@@ -67,7 +67,7 @@ def format_builtin_metrics_header(builtin_metrics: List[str]) -> List[str]:
     """Format the built-in metrics header section."""
     output = ["Built-in metrics (available for all operators):"]
     for metric in sorted(builtin_metrics):
-        output.append(f"  {metric}")
+        output.append(f"\t{metric}")
     return output
 
 
@@ -89,9 +89,9 @@ def format_backend_entry(backend_name: str, backend_info: Dict[str, any]) -> str
     status_str = f" [{', '.join(status_indicators)}]" if status_indicators else ""
 
     if label != backend_name:
-        return f"    {backend_name} (label: {label}){status_str}"
+        return f"\t\t{backend_name} (label: {label}){status_str}"
     else:
-        return f"    {backend_name}{status_str}"
+        return f"\t\t{backend_name}{status_str}"
 
 
 def format_metrics_section(
@@ -107,14 +107,14 @@ def format_metrics_section(
     overridden = metrics_data[op_name].get("overridden", [])
 
     if custom:
-        output.append("  Custom metrics:")
+        output.append("\tCustom metrics:")
         for metric in sorted(custom):
-            output.append(f"    {metric}")
+            output.append(f"\t\t{metric}")
 
     if overridden:
-        output.append("  Overridden metrics:")
+        output.append("\tOverridden metrics:")
         for metric in sorted(overridden):
-            output.append(f"    {metric}")
+            output.append(f"\t\t{metric}")
 
     return output
 
@@ -128,7 +128,7 @@ def format_backends_section(
     if op_name not in backends_data or not backends_data[op_name]:
         return output
 
-    output.append("  Backends:")
+    output.append("\tBackends:")
     backends = backends_data[op_name]
 
     for backend_name in sorted(backends.keys()):
@@ -277,7 +277,7 @@ def list_operator_details(
             output = []
             output.append("Built-in metrics (available for all operators):")
             for metric in sorted(builtin_metrics):
-                output.append(f"  {metric}")
+                output.append(f"\t{metric}")
             output.append(
                 "\nNote: Use --op or --op-collection to show operator-specific details."
             )
@@ -287,7 +287,7 @@ def list_operator_details(
             output = []
             output.append("Built-in metrics (available for all operators):")
             for metric in sorted(builtin_metrics):
-                output.append(f"  {metric}")
+                output.append(f"\t{metric}")
             return "\n".join(output)
         elif show_backends:
             # Global backends case - no global backends exist

--- a/tritonbench/utils/list_operator_details.py
+++ b/tritonbench/utils/list_operator_details.py
@@ -6,6 +6,10 @@ import sys
 from dataclasses import fields
 from typing import Dict, List, Optional
 
+# Indentation constants for consistent formatting
+INDENT = "  "  # Base indentation unit (2 spaces)
+INDENT2 = INDENT * 2  # Double indentation (4 spaces)
+
 from tritonbench.operators_collection import list_operators_by_collection
 from tritonbench.utils.operator_utils import (
     batch_load_operators,
@@ -67,7 +71,7 @@ def format_builtin_metrics_header(builtin_metrics: List[str]) -> List[str]:
     """Format the built-in metrics header section."""
     output = ["Built-in metrics (available for all operators):"]
     for metric in sorted(builtin_metrics):
-        output.append(f"\t{metric}")
+        output.append(f"{INDENT}{metric}")
     return output
 
 
@@ -89,9 +93,9 @@ def format_backend_entry(backend_name: str, backend_info: Dict[str, any]) -> str
     status_str = f" [{', '.join(status_indicators)}]" if status_indicators else ""
 
     if label != backend_name:
-        return f"\t\t{backend_name} (label: {label}){status_str}"
+        return f"{INDENT2}{backend_name} (label: {label}){status_str}"
     else:
-        return f"\t\t{backend_name}{status_str}"
+        return f"{INDENT2}{backend_name}{status_str}"
 
 
 def format_metrics_section(
@@ -107,14 +111,14 @@ def format_metrics_section(
     overridden = metrics_data[op_name].get("overridden", [])
 
     if custom:
-        output.append("\tCustom metrics:")
+        output.append(f"{INDENT}Custom metrics:")
         for metric in sorted(custom):
-            output.append(f"\t\t{metric}")
+            output.append(f"{INDENT2}{metric}")
 
     if overridden:
-        output.append("\tOverridden metrics:")
+        output.append(f"{INDENT}Overridden metrics:")
         for metric in sorted(overridden):
-            output.append(f"\t\t{metric}")
+            output.append(f"{INDENT2}{metric}")
 
     return output
 
@@ -128,7 +132,7 @@ def format_backends_section(
     if op_name not in backends_data or not backends_data[op_name]:
         return output
 
-    output.append("\tBackends:")
+    output.append(f"{INDENT}Backends:")
     backends = backends_data[op_name]
 
     for backend_name in sorted(backends.keys()):
@@ -277,7 +281,7 @@ def list_operator_details(
             output = []
             output.append("Built-in metrics (available for all operators):")
             for metric in sorted(builtin_metrics):
-                output.append(f"\t{metric}")
+                output.append(f"{INDENT}{metric}")
             output.append(
                 "\nNote: Use --op or --op-collection to show operator-specific details."
             )
@@ -287,7 +291,7 @@ def list_operator_details(
             output = []
             output.append("Built-in metrics (available for all operators):")
             for metric in sorted(builtin_metrics):
-                output.append(f"\t{metric}")
+                output.append(f"{INDENT}{metric}")
             return "\n".join(output)
         elif show_backends:
             # Global backends case - no global backends exist


### PR DESCRIPTION
as discussed in #301 , a follow-up pr to improve the format style

```
python run.py --list-backends --op flash_attention
INFO:root:TMA benchmarks will be running without grid constant TMA descriptor.
TMA benchmarks will be running without grid constant TMA descriptor.

Operator: flash_attention
  Backends:
    aten [baseline]
    cudnn (label: cudnn-91002) [disabled]
    flash_v2 [disabled]
    flash_v3 [disabled]
    flex_attention
    pallas [disabled]
    sdpa
    tile [disabled]
    tk [disabled]
    triton_tutorial_flash_v2
    triton_tutorial_flash_v2_tma
    triton_tutorial_flash_v2_tma_ws
    triton_tutorial_flash_v2_tma_ws_persistent
    triton_tutorial_flash_v2_ws
    xformers [disabled]
    xformers_splitk [disabled, fwd_only]
```