### PR TITLE
Add --only-match-mode=prefix-with-baseline to enable specific impl prefix  together  with  baseline

### DIFF
--- a/tritonbench/utils/parser.py
+++ b/tritonbench/utils/parser.py
@@ -129,6 +129,12 @@ def get_parser(args=None):
         help="Specify one or multiple kernel implementations to skip.",
     )
     parser.add_argument(
+        "--only-match-mode",
+        default="exact",
+        choices=["exact", "prefix-with-baseline"],
+        help="Match mode for --only argument. 'exact' for full string match, 'prefix-with-baseline' for prefix match as well as the existing baseline. Default: exact",
+    )
+    parser.add_argument(
         "--baseline", type=str, default=None, help="Override default baseline."
     )
     parser.add_argument(


### PR DESCRIPTION
During Helion development, it's quite common to want to compare Helion impl vs. baseline (since speedup numbers are all compared against baseline). With this PR, we can do `--baseline --only "helion" --only-match-mode=prefix` to enable specific impl prefix to make this much easier to run.