### PR TITLE
Fix metric output order non-determinism

### DIFF
--- a/tritonbench/utils/triton_op.py
+++ b/tritonbench/utils/triton_op.py
@@ -719,7 +719,7 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
         self.requires_grad = not (self.mode == Mode.FWD_NO_GRAD)
         self.device = tb_args.device
         self.required_metrics = (
-            list(set(tb_args.metrics.split(",")))
+            list(dict.fromkeys(tb_args.metrics.split(",")))
             if tb_args.metrics
             else self.DEFAULT_METRICS
         )
@@ -866,7 +866,9 @@ class BenchmarkOperator(metaclass=PostInitProcessor):
                                     benchmarks.append(bm)
                                     break
                     else:  # exact mode (default)
-                        benchmarks = list(set(self._only))  # remove duplicates
+                        benchmarks = list(
+                            dict.fromkeys(self._only)
+                        )  # remove duplicates while preserving order
                 else:
                     benchmarks = find_enabled_benchmarks(
                         self.mode, REGISTERED_BENCHMARKS[self.name], self._skip


### PR DESCRIPTION
If user has multiple gpus, it's common to want to shard the inputs and run each shard on a different GPU. However, currently the output metric order is non-deterministic (e.g. if user specifies `accuracy,speedup,latency` metrics, their display order in the output table / CSV is non-deterministic). This PR fixes it to make their display order deterministic.

I will run through internal CI to make sure it passes.